### PR TITLE
Apt files cleanup

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.1/Dockerfile
+++ b/images/1.4.0.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.10/Dockerfile
+++ b/images/1.4.0.10/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.11/Dockerfile
+++ b/images/1.4.0.11/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.12/Dockerfile
+++ b/images/1.4.0.12/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.13/Dockerfile
+++ b/images/1.4.0.13/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.14/Dockerfile
+++ b/images/1.4.0.14/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.17/Dockerfile
+++ b/images/1.4.0.17/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.2/Dockerfile
+++ b/images/1.4.0.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.3/Dockerfile
+++ b/images/1.4.0.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.4/Dockerfile
+++ b/images/1.4.0.4/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.5/Dockerfile
+++ b/images/1.4.0.5/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.6/Dockerfile
+++ b/images/1.4.0.6/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.7/Dockerfile
+++ b/images/1.4.0.7/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.8/Dockerfile
+++ b/images/1.4.0.8/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.0.9/Dockerfile
+++ b/images/1.4.0.9/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.1.0/Dockerfile
+++ b/images/1.4.1.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.10.0/Dockerfile
+++ b/images/1.4.10.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.11.0/Dockerfile
+++ b/images/1.4.11.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.11.1/Dockerfile
+++ b/images/1.4.11.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.2.5/Dockerfile
+++ b/images/1.4.2.5/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.3.0/Dockerfile
+++ b/images/1.4.3.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.4.0/Dockerfile
+++ b/images/1.4.4.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.4.1/Dockerfile
+++ b/images/1.4.4.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.5.1/Dockerfile
+++ b/images/1.4.5.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.6.1/Dockerfile
+++ b/images/1.4.6.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.6.2/Dockerfile
+++ b/images/1.4.6.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.7.0/Dockerfile
+++ b/images/1.4.7.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.7.2/Dockerfile
+++ b/images/1.4.7.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.7.3/Dockerfile
+++ b/images/1.4.7.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.8.2/Dockerfile
+++ b/images/1.4.8.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.8.3/Dockerfile
+++ b/images/1.4.8.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.4.9.0/Dockerfile
+++ b/images/1.4.9.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.1/Dockerfile
+++ b/images/1.5.0.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.13/Dockerfile
+++ b/images/1.5.0.13/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.15/Dockerfile
+++ b/images/1.5.0.15/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.17/Dockerfile
+++ b/images/1.5.0.17/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.2/Dockerfile
+++ b/images/1.5.0.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.3/Dockerfile
+++ b/images/1.5.0.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.5/Dockerfile
+++ b/images/1.5.0.5/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.0.9/Dockerfile
+++ b/images/1.5.0.9/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.1.0/Dockerfile
+++ b/images/1.5.1.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.2.0/Dockerfile
+++ b/images/1.5.2.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.3.0/Dockerfile
+++ b/images/1.5.3.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.3.1/Dockerfile
+++ b/images/1.5.3.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.4.0/Dockerfile
+++ b/images/1.5.4.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.4.1/Dockerfile
+++ b/images/1.5.4.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.5.0/Dockerfile
+++ b/images/1.5.5.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.6.0/Dockerfile
+++ b/images/1.5.6.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.6.1/Dockerfile
+++ b/images/1.5.6.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.6.2/Dockerfile
+++ b/images/1.5.6.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.5.6.3/Dockerfile
+++ b/images/1.5.6.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.1/Dockerfile
+++ b/images/1.6.0.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.11/Dockerfile
+++ b/images/1.6.0.11/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.12/Dockerfile
+++ b/images/1.6.0.12/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.13/Dockerfile
+++ b/images/1.6.0.13/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.14/Dockerfile
+++ b/images/1.6.0.14/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.2/Dockerfile
+++ b/images/1.6.0.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.3/Dockerfile
+++ b/images/1.6.0.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.4/Dockerfile
+++ b/images/1.6.0.4/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.5/Dockerfile
+++ b/images/1.6.0.5/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.6/Dockerfile
+++ b/images/1.6.0.6/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.7/Dockerfile
+++ b/images/1.6.0.7/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.8/Dockerfile
+++ b/images/1.6.0.8/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.0.9/Dockerfile
+++ b/images/1.6.0.9/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.1.0/Dockerfile
+++ b/images/1.6.1.0/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.1.1/Dockerfile
+++ b/images/1.6.1.1/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.1.2/Dockerfile
+++ b/images/1.6.1.2/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.1.3/Dockerfile
+++ b/images/1.6.1.3/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 

--- a/images/1.6.1.4/Dockerfile
+++ b/images/1.6.1.4/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 		mysql-server \
 		wget \
 		unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install iconv mcrypt pdo mysql pdo_mysql mbstring soap gd
 


### PR DESCRIPTION
Fix database ready before start application is needed to run PrestaShop in a docker compose file, to use a separate (and persistent) docker image of MySql.
Ref: https://docs.docker.com/compose/faq/#how-do-i-get-compose-to-wait-for-my-database-to-be-ready-before-starting-my-application

PS: after installed netcat I've removed lists/*
Ref: https://docs.docker.com/engine/articles/dockerfile_best-practices/#apt-get
