### PR TITLE
Use domain specified for auto-install

### DIFF
--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -61,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 		fi
 
-		php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain=$(hostname -i) --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain=$PS_DOMAIN --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
 			--newsletter=0 --send_email=0

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -61,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 		fi
 
-		php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain=$PS_DOMAIN --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
 			--newsletter=0 --send_email=0


### PR DESCRIPTION
feat: auto-install

Use "PS_DOMAIN" variable for auto-install and not the hostname of container.

When installation on external server, we can directly use the default domain without use proxy for use local docker address.