### PR TITLE
Reapply PrestaShop files to handle empty volumes

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -46,7 +46,7 @@ ENV PS_VERSION {PS_VERSION}
 # Get PrestaShop
 ADD {PS_URL} /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/config_files/ps-extractor.sh
+++ b/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.1/Dockerfile
+++ b/images/1.4.0.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.1/config_files/docker_run.sh
+++ b/images/1.4.0.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.1/config_files/ps-extractor.sh
+++ b/images/1.4.0.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.10/Dockerfile
+++ b/images/1.4.0.10/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.10
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.10.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.10/config_files/docker_run.sh
+++ b/images/1.4.0.10/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.10/config_files/ps-extractor.sh
+++ b/images/1.4.0.10/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.11/Dockerfile
+++ b/images/1.4.0.11/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.11
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.11.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.11/config_files/docker_run.sh
+++ b/images/1.4.0.11/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.11/config_files/ps-extractor.sh
+++ b/images/1.4.0.11/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.12/Dockerfile
+++ b/images/1.4.0.12/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.12
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.12.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.12/config_files/docker_run.sh
+++ b/images/1.4.0.12/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.12/config_files/ps-extractor.sh
+++ b/images/1.4.0.12/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.13/Dockerfile
+++ b/images/1.4.0.13/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.13
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.13.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.13/config_files/docker_run.sh
+++ b/images/1.4.0.13/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.13/config_files/ps-extractor.sh
+++ b/images/1.4.0.13/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.14/Dockerfile
+++ b/images/1.4.0.14/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.14
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.14.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.14/config_files/docker_run.sh
+++ b/images/1.4.0.14/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.14/config_files/ps-extractor.sh
+++ b/images/1.4.0.14/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.17/Dockerfile
+++ b/images/1.4.0.17/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.17
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.17.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.17/config_files/docker_run.sh
+++ b/images/1.4.0.17/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.17/config_files/ps-extractor.sh
+++ b/images/1.4.0.17/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.2/Dockerfile
+++ b/images/1.4.0.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.2/config_files/docker_run.sh
+++ b/images/1.4.0.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.2/config_files/ps-extractor.sh
+++ b/images/1.4.0.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.3/Dockerfile
+++ b/images/1.4.0.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.3/config_files/docker_run.sh
+++ b/images/1.4.0.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.3/config_files/ps-extractor.sh
+++ b/images/1.4.0.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.4/Dockerfile
+++ b/images/1.4.0.4/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.4
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.4.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.4/config_files/docker_run.sh
+++ b/images/1.4.0.4/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.4/config_files/ps-extractor.sh
+++ b/images/1.4.0.4/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.5/Dockerfile
+++ b/images/1.4.0.5/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.5
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.5.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.5/config_files/docker_run.sh
+++ b/images/1.4.0.5/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.5/config_files/ps-extractor.sh
+++ b/images/1.4.0.5/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.6/Dockerfile
+++ b/images/1.4.0.6/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.6
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.6.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.6/config_files/docker_run.sh
+++ b/images/1.4.0.6/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.6/config_files/ps-extractor.sh
+++ b/images/1.4.0.6/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.7/Dockerfile
+++ b/images/1.4.0.7/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.7
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.7.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.7/config_files/docker_run.sh
+++ b/images/1.4.0.7/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.7/config_files/ps-extractor.sh
+++ b/images/1.4.0.7/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.8/Dockerfile
+++ b/images/1.4.0.8/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.8
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.8.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.8/config_files/docker_run.sh
+++ b/images/1.4.0.8/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.8/config_files/ps-extractor.sh
+++ b/images/1.4.0.8/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.0.9/Dockerfile
+++ b/images/1.4.0.9/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.0.9
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.0.9.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.0.9/config_files/docker_run.sh
+++ b/images/1.4.0.9/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.0.9/config_files/ps-extractor.sh
+++ b/images/1.4.0.9/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.1.0/Dockerfile
+++ b/images/1.4.1.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.1.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.1.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.1.0/config_files/docker_run.sh
+++ b/images/1.4.1.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.1.0/config_files/ps-extractor.sh
+++ b/images/1.4.1.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.10.0/Dockerfile
+++ b/images/1.4.10.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.10.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.10.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.10.0/config_files/docker_run.sh
+++ b/images/1.4.10.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.10.0/config_files/ps-extractor.sh
+++ b/images/1.4.10.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.11.0/Dockerfile
+++ b/images/1.4.11.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.11.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.11.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.11.0/config_files/docker_run.sh
+++ b/images/1.4.11.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.11.0/config_files/ps-extractor.sh
+++ b/images/1.4.11.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.11.1/Dockerfile
+++ b/images/1.4.11.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.11.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.11.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.11.1/config_files/docker_run.sh
+++ b/images/1.4.11.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.11.1/config_files/ps-extractor.sh
+++ b/images/1.4.11.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.2.5/Dockerfile
+++ b/images/1.4.2.5/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.2.5
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.2.5.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.2.5/config_files/docker_run.sh
+++ b/images/1.4.2.5/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.2.5/config_files/ps-extractor.sh
+++ b/images/1.4.2.5/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.3.0/Dockerfile
+++ b/images/1.4.3.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.3.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.3.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.3.0/config_files/docker_run.sh
+++ b/images/1.4.3.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.3.0/config_files/ps-extractor.sh
+++ b/images/1.4.3.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.4.0/Dockerfile
+++ b/images/1.4.4.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.4.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.4.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.4.0/config_files/docker_run.sh
+++ b/images/1.4.4.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.4.0/config_files/ps-extractor.sh
+++ b/images/1.4.4.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.4.1/Dockerfile
+++ b/images/1.4.4.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.4.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.4.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.4.1/config_files/docker_run.sh
+++ b/images/1.4.4.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.4.1/config_files/ps-extractor.sh
+++ b/images/1.4.4.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.5.1/Dockerfile
+++ b/images/1.4.5.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.5.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.5.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.5.1/config_files/docker_run.sh
+++ b/images/1.4.5.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.5.1/config_files/ps-extractor.sh
+++ b/images/1.4.5.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.6.1/Dockerfile
+++ b/images/1.4.6.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.6.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.6.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.6.1/config_files/docker_run.sh
+++ b/images/1.4.6.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.6.1/config_files/ps-extractor.sh
+++ b/images/1.4.6.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.6.2/Dockerfile
+++ b/images/1.4.6.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.6.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.6.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.6.2/config_files/docker_run.sh
+++ b/images/1.4.6.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.6.2/config_files/ps-extractor.sh
+++ b/images/1.4.6.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.7.0/Dockerfile
+++ b/images/1.4.7.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.7.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.7.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.7.0/config_files/docker_run.sh
+++ b/images/1.4.7.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.7.0/config_files/ps-extractor.sh
+++ b/images/1.4.7.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.7.2/Dockerfile
+++ b/images/1.4.7.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.7.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.7.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.7.2/config_files/docker_run.sh
+++ b/images/1.4.7.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.7.2/config_files/ps-extractor.sh
+++ b/images/1.4.7.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.7.3/Dockerfile
+++ b/images/1.4.7.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.7.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.7.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.7.3/config_files/docker_run.sh
+++ b/images/1.4.7.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.7.3/config_files/ps-extractor.sh
+++ b/images/1.4.7.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.8.2/Dockerfile
+++ b/images/1.4.8.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.8.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.8.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.8.2/config_files/docker_run.sh
+++ b/images/1.4.8.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.8.2/config_files/ps-extractor.sh
+++ b/images/1.4.8.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.8.3/Dockerfile
+++ b/images/1.4.8.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.8.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.8.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.8.3/config_files/docker_run.sh
+++ b/images/1.4.8.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.8.3/config_files/ps-extractor.sh
+++ b/images/1.4.8.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.4.9.0/Dockerfile
+++ b/images/1.4.9.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.4.9.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.4.9.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.4.9.0/config_files/docker_run.sh
+++ b/images/1.4.9.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.4.9.0/config_files/ps-extractor.sh
+++ b/images/1.4.9.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.1/Dockerfile
+++ b/images/1.5.0.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.1/config_files/docker_run.sh
+++ b/images/1.5.0.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.1/config_files/ps-extractor.sh
+++ b/images/1.5.0.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.13/Dockerfile
+++ b/images/1.5.0.13/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.13
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.13.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.13/config_files/docker_run.sh
+++ b/images/1.5.0.13/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.13/config_files/ps-extractor.sh
+++ b/images/1.5.0.13/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.15/Dockerfile
+++ b/images/1.5.0.15/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.15
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.15.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.15/config_files/docker_run.sh
+++ b/images/1.5.0.15/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.15/config_files/ps-extractor.sh
+++ b/images/1.5.0.15/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.17/Dockerfile
+++ b/images/1.5.0.17/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.17
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.17.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.17/config_files/docker_run.sh
+++ b/images/1.5.0.17/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.17/config_files/ps-extractor.sh
+++ b/images/1.5.0.17/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.2/Dockerfile
+++ b/images/1.5.0.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.2/config_files/docker_run.sh
+++ b/images/1.5.0.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.2/config_files/ps-extractor.sh
+++ b/images/1.5.0.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.3/Dockerfile
+++ b/images/1.5.0.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.3/config_files/docker_run.sh
+++ b/images/1.5.0.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.3/config_files/ps-extractor.sh
+++ b/images/1.5.0.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.5/Dockerfile
+++ b/images/1.5.0.5/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.5
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.5.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.5/config_files/docker_run.sh
+++ b/images/1.5.0.5/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.5/config_files/ps-extractor.sh
+++ b/images/1.5.0.5/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.0.9/Dockerfile
+++ b/images/1.5.0.9/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.0.9
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.0.9.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.0.9/config_files/docker_run.sh
+++ b/images/1.5.0.9/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.0.9/config_files/ps-extractor.sh
+++ b/images/1.5.0.9/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.1.0/Dockerfile
+++ b/images/1.5.1.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.1.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.1.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.1.0/config_files/docker_run.sh
+++ b/images/1.5.1.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.1.0/config_files/ps-extractor.sh
+++ b/images/1.5.1.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.2.0/Dockerfile
+++ b/images/1.5.2.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.2.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.2.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.2.0/config_files/docker_run.sh
+++ b/images/1.5.2.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.2.0/config_files/ps-extractor.sh
+++ b/images/1.5.2.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.3.0/Dockerfile
+++ b/images/1.5.3.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.3.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.3.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.3.0/config_files/docker_run.sh
+++ b/images/1.5.3.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.3.0/config_files/ps-extractor.sh
+++ b/images/1.5.3.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.3.1/Dockerfile
+++ b/images/1.5.3.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.3.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.3.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.3.1/config_files/docker_run.sh
+++ b/images/1.5.3.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.3.1/config_files/ps-extractor.sh
+++ b/images/1.5.3.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.4.0/Dockerfile
+++ b/images/1.5.4.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.4.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.4.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.4.0/config_files/docker_run.sh
+++ b/images/1.5.4.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.4.0/config_files/ps-extractor.sh
+++ b/images/1.5.4.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.4.1/Dockerfile
+++ b/images/1.5.4.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.4.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.4.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.4.1/config_files/docker_run.sh
+++ b/images/1.5.4.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.4.1/config_files/ps-extractor.sh
+++ b/images/1.5.4.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.5.0/Dockerfile
+++ b/images/1.5.5.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.5.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.5.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.5.0/config_files/docker_run.sh
+++ b/images/1.5.5.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.5.0/config_files/ps-extractor.sh
+++ b/images/1.5.5.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.6.0/Dockerfile
+++ b/images/1.5.6.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.6.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.6.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.6.0/config_files/docker_run.sh
+++ b/images/1.5.6.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.6.0/config_files/ps-extractor.sh
+++ b/images/1.5.6.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.6.1/Dockerfile
+++ b/images/1.5.6.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.6.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.6.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.6.1/config_files/docker_run.sh
+++ b/images/1.5.6.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.6.1/config_files/ps-extractor.sh
+++ b/images/1.5.6.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.6.2/Dockerfile
+++ b/images/1.5.6.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.6.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.6.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.6.2/config_files/docker_run.sh
+++ b/images/1.5.6.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.6.2/config_files/ps-extractor.sh
+++ b/images/1.5.6.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.5.6.3/Dockerfile
+++ b/images/1.5.6.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.5.6.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.5.6.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.5.6.3/config_files/docker_run.sh
+++ b/images/1.5.6.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.5.6.3/config_files/ps-extractor.sh
+++ b/images/1.5.6.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.1/Dockerfile
+++ b/images/1.6.0.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.1/config_files/docker_run.sh
+++ b/images/1.6.0.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.1/config_files/ps-extractor.sh
+++ b/images/1.6.0.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.11/Dockerfile
+++ b/images/1.6.0.11/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.11
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.11.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.11/config_files/docker_run.sh
+++ b/images/1.6.0.11/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.11/config_files/ps-extractor.sh
+++ b/images/1.6.0.11/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.12/Dockerfile
+++ b/images/1.6.0.12/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.12
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.12.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.12/config_files/docker_run.sh
+++ b/images/1.6.0.12/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.12/config_files/ps-extractor.sh
+++ b/images/1.6.0.12/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.13/Dockerfile
+++ b/images/1.6.0.13/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.13
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.13.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.13/config_files/docker_run.sh
+++ b/images/1.6.0.13/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.13/config_files/ps-extractor.sh
+++ b/images/1.6.0.13/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.14/Dockerfile
+++ b/images/1.6.0.14/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.14
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.14.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.14/config_files/docker_run.sh
+++ b/images/1.6.0.14/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.14/config_files/ps-extractor.sh
+++ b/images/1.6.0.14/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.2/Dockerfile
+++ b/images/1.6.0.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.2/config_files/docker_run.sh
+++ b/images/1.6.0.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.2/config_files/ps-extractor.sh
+++ b/images/1.6.0.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.3/Dockerfile
+++ b/images/1.6.0.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.3/config_files/docker_run.sh
+++ b/images/1.6.0.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.3/config_files/ps-extractor.sh
+++ b/images/1.6.0.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.4/Dockerfile
+++ b/images/1.6.0.4/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.4
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.4.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.4/config_files/docker_run.sh
+++ b/images/1.6.0.4/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.4/config_files/ps-extractor.sh
+++ b/images/1.6.0.4/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.5/Dockerfile
+++ b/images/1.6.0.5/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.5
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.5.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.5/config_files/docker_run.sh
+++ b/images/1.6.0.5/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.5/config_files/ps-extractor.sh
+++ b/images/1.6.0.5/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.6/Dockerfile
+++ b/images/1.6.0.6/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.6
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.6.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.6/config_files/docker_run.sh
+++ b/images/1.6.0.6/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.6/config_files/ps-extractor.sh
+++ b/images/1.6.0.6/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.7/Dockerfile
+++ b/images/1.6.0.7/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.7
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.7.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.7/config_files/docker_run.sh
+++ b/images/1.6.0.7/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.7/config_files/ps-extractor.sh
+++ b/images/1.6.0.7/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.8/Dockerfile
+++ b/images/1.6.0.8/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.8
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.8.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.8/config_files/docker_run.sh
+++ b/images/1.6.0.8/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.8/config_files/ps-extractor.sh
+++ b/images/1.6.0.8/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.0.9/Dockerfile
+++ b/images/1.6.0.9/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.0.9
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.0.9.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.0.9/config_files/docker_run.sh
+++ b/images/1.6.0.9/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.0.9/config_files/ps-extractor.sh
+++ b/images/1.6.0.9/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.0/Dockerfile
+++ b/images/1.6.1.0/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.0
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.0/config_files/docker_run.sh
+++ b/images/1.6.1.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.0/config_files/ps-extractor.sh
+++ b/images/1.6.1.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.1/Dockerfile
+++ b/images/1.6.1.1/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.1
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.1/config_files/docker_run.sh
+++ b/images/1.6.1.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.1/config_files/ps-extractor.sh
+++ b/images/1.6.1.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.2/Dockerfile
+++ b/images/1.6.1.2/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.2
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.2/config_files/docker_run.sh
+++ b/images/1.6.1.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.2/config_files/ps-extractor.sh
+++ b/images/1.6.1.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.3/Dockerfile
+++ b/images/1.6.1.3/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.3
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.3.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.3/config_files/docker_run.sh
+++ b/images/1.6.1.3/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.3/config_files/ps-extractor.sh
+++ b/images/1.6.1.3/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.4/Dockerfile
+++ b/images/1.6.1.4/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.4
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.4.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.4/config_files/docker_run.sh
+++ b/images/1.6.1.4/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.4/config_files/ps-extractor.sh
+++ b/images/1.6.1.4/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.5/Dockerfile
+++ b/images/1.6.1.5/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.5
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.5.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.5/config_files/docker_run.sh
+++ b/images/1.6.1.5/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.5/config_files/ps-extractor.sh
+++ b/images/1.6.1.5/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.6/Dockerfile
+++ b/images/1.6.1.6/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.6
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.6.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.6/config_files/docker_run.sh
+++ b/images/1.6.1.6/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.6/config_files/ps-extractor.sh
+++ b/images/1.6.1.6/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.7/Dockerfile
+++ b/images/1.6.1.7/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.7
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.7.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.7/config_files/docker_run.sh
+++ b/images/1.6.1.7/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.7/config_files/ps-extractor.sh
+++ b/images/1.6.1.7/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.8/Dockerfile
+++ b/images/1.6.1.8/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.8
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.8.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.8/config_files/docker_run.sh
+++ b/images/1.6.1.8/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.8/config_files/ps-extractor.sh
+++ b/images/1.6.1.8/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.6.1.9/Dockerfile
+++ b/images/1.6.1.9/Dockerfile
@@ -32,20 +32,21 @@ RUN apt-get update \
 		libpng12-dev \
 		libfreetype6-dev \
 		libxml2-dev \
+		libicu-dev \
 		mysql-client \
 		mysql-server \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install iconv mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
+    && docker-php-ext-install iconv intl mcrypt opcache pdo mysql pdo_mysql mbstring soap gd zip
 
 ENV PS_VERSION 1.6.1.9
 
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.6.1.9.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.6.1.9/config_files/docker_run.sh
+++ b/images/1.6.1.9/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.6.1.9/config_files/ps-extractor.sh
+++ b/images/1.6.1.9/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.7.0.0/Dockerfile
+++ b/images/1.7.0.0/Dockerfile
@@ -46,7 +46,7 @@ ENV PS_VERSION 1.7.0.0
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.7.0.0.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.7.0.0/config_files/docker_run.sh
+++ b/images/1.7.0.0/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.7.0.0/config_files/ps-extractor.sh
+++ b/images/1.7.0.0/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.7.0.1/Dockerfile
+++ b/images/1.7.0.1/Dockerfile
@@ -46,7 +46,7 @@ ENV PS_VERSION 1.7.0.1
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.7.0.1.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.7.0.1/config_files/docker_run.sh
+++ b/images/1.7.0.1/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.7.0.1/config_files/ps-extractor.sh
+++ b/images/1.7.0.1/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"

--- a/images/1.7.0.2/Dockerfile
+++ b/images/1.7.0.2/Dockerfile
@@ -46,7 +46,7 @@ ENV PS_VERSION 1.7.0.2
 # Get PrestaShop
 ADD https://www.prestashop.com/download/old/prestashop_1.7.0.2.zip /tmp/prestashop.zip
 COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip /tmp/ps-extractor.sh
+RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration

--- a/images/1.7.0.2/config_files/docker_run.sh
+++ b/images/1.7.0.2/config_files/docker_run.sh
@@ -25,6 +25,9 @@ while [ $RET -ne 0 ]; do
 done
 
 if [ ! -f ./config/settings.inc.php  ]; then
+	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
+	bash /tmp/ps-extractor.sh /tmp/data-ps
+
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
 		sed -ie "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php

--- a/images/1.7.0.2/config_files/ps-extractor.sh
+++ b/images/1.7.0.2/config_files/ps-extractor.sh
@@ -5,9 +5,9 @@ destination="/var/www/html"
 
 if [[ -n "$folder" ]]; then
     if [ -d $folder/prestashop ]; then
-       mv -v $folder/prestashop/* $destination
+        cp -n -R $folder/prestashop/* $destination
     else
-        unzip -q $folder/prestashop.zip -d $destination
+        unzip -n -q $folder/prestashop.zip -d $destination
     fi
 else
     echo "Missing folder to move"


### PR DESCRIPTION
Fixes #3 

In order to avoid empty folders when enabling a volume, we extract the whole PrestaShop zip content at the first start.
If the file already exists, it is ignored.