### PR TITLE
Update readme for automatic install details

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ However, if you want to customize the container execution, here are many availab
 * **DB_PASSWD**: Override default MySQL password *(default value: admin)*
 * **DB_PREFIX**: Override default tables prefix *(default value: ps_)*
 * **DB_NAME**: Override default database name *(default value: prestashop)*
-* **PS_INSTALL_AUTO=1**: The installation will be executed. Useful to initialize your image faster. (Please note that PrestaShop can be installed automatically from PS 1.5)
+* **PS_INSTALL_AUTO=1**: The installation will be executed. Useful to initialize your image faster. In some configurations, you may need to set **PS_DOMAIN** or **PS_HANDLE_DYNAMIC_DOMAIN** as well. (Please note that PrestaShop can be installed automatically from PS 1.5)
+* **PS_DOMAIN**: When installing automatically your shop, you can tell the shop how it will be reached. For advanced users only. *(no default value)*
 * **PS_LANGUAGE**: Change the default language installed with PrestaShop *(default value: en)*
 * **PS_COUNTRY**: Change the default country installed with PrestaShop *(default value: gb)*
 * **PS_FOLDER_ADMIN**: Change the name of the `admin` folder *(default value: admin. But will be automatically changed later)*


### PR DESCRIPTION
Closes #76 

This PR gives additional details on how to reach successfully a shop after an automatic installation.
Some network configuration (typically on virtualized docker Host or on Windows / Mac OS), may make PrestaShop choose an unreachable IP address by default.