### PR TITLE
Re-arrange volumes

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -1,24 +1,23 @@
 FROM php:{PHP_VERSION}-apache
+LABEL 'maintainer="Thomas Nabord <thomas.nabord@prestashop.com>"'
 
-MAINTAINER Thomas Nabord <thomas.nabord@prestashop.com>
-
-ENV PS_DOMAIN <to be defined>
-ENV DB_SERVER <to be defined>
-ENV DB_PORT 3306
-ENV DB_NAME prestashop
-ENV DB_USER root
-ENV DB_PASSWD admin
-ENV ADMIN_MAIL demo@prestashop.com
-ENV ADMIN_PASSWD prestashop_demo
-ENV PS_LANGUAGE en
-ENV PS_COUNTRY gb
-ENV PS_INSTALL_AUTO 0
-ENV PS_DEV_MODE 0
-ENV PS_HOST_MODE 0
-ENV PS_HANDLE_DYNAMIC_DOMAIN 0
-
-ENV PS_FOLDER_ADMIN admin
-ENV PS_FOLDER_INSTALL install
+ENV PS_DOMAIN <to be defined> \
+DB_SERVER <to be defined> \
+DB_PORT 3306  \
+DB_NAME prestashop  \
+DB_USER root  \
+DB_PASSWD admin  \
+ADMIN_MAIL demo@prestashop.com  \
+ADMIN_PASSWD prestashop_demo  \
+PS_LANGUAGE en  \
+PS_COUNTRY gb  \
+PS_INSTALL_AUTO 0  \
+PS_DEV_MODE 0  \
+PS_HOST_MODE 0  \
+PS_HANDLE_DYNAMIC_DOMAIN 0  \
+PS_FOLDER_ADMIN admin  \
+PS_FOLDER_INSTALL install \
+PS_VERSION {PS_VERSION}
 
 RUN apt-get update \
 	&& apt-get install -y libmcrypt-dev \
@@ -40,24 +39,27 @@ RUN docker-php-source extract \
 	&& if [ -d "/usr/src/php/ext/opcache" ]; then docker-php-ext-install opcache; fi \
 	&& docker-php-source delete
 
-ENV PS_VERSION {PS_VERSION}
-
 # Get PrestaShop
 ADD {PS_URL} /tmp/prestashop.zip
-COPY config_files/ps-extractor.sh /tmp/
-RUN mkdir /tmp/data-ps && unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ && bash /tmp/ps-extractor.sh /tmp/data-ps && rm /tmp/prestashop.zip
+
+# Prepare install and CMD script
+COPY config_files/ps-extractor.sh config_files/docker_run.sh /tmp/
+
+# Extract
+RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
+	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
+	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
+	&& rm /tmp/prestashop.zip
 COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
 
-VOLUME /var/www/html/modules
-VOLUME /var/www/html/themes
-VOLUME /var/www/html/override
+# Declare
+VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
 
-COPY config_files/docker_run.sh /tmp/
+# Run
 CMD ["/tmp/docker_run.sh"]

--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -1,24 +1,23 @@
 FROM php:{PHP_VERSION}-apache
-LABEL 'maintainer="Thomas Nabord <thomas.nabord@prestashop.com>"'
+LABEL maintainer="Thomas Nabord <thomas.nabord@prestashop.com>"
 
-ENV PS_DOMAIN <to be defined> \
-DB_SERVER <to be defined> \
-DB_PORT 3306 \
-DB_NAME prestashop \
-DB_USER root \
-DB_PASSWD admin \
-ADMIN_MAIL demo@prestashop.com \
-ADMIN_PASSWD prestashop_demo \
-PS_LANGUAGE en  
-PS_COUNTRY gb \
-PS_INSTALL_AUTO 0 \
-PS_ERASE_MYSQL 0 \
-PS_DEV_MODE 0 \
-PS_HOST_MODE 0 \
-PS_HANDLE_DYNAMIC_DOMAIN 0 \
-PS_FOLDER_ADMIN admin \
-PS_FOLDER_INSTALL install \
-PS_VERSION {PS_VERSION}
+ENV PS_DOMAIN="<to be defined>" \
+DB_SERVER="<to be defined>" \
+DB_PORT=3306 \
+DB_NAME=prestashop \
+DB_USER=root \
+DB_PASSWD=admin \
+ADMIN_MAIL=demo@prestashop.com \
+ADMIN_PASSWD=prestashop_demo \
+PS_LANGUAGE=en \
+PS_COUNTRY=gb \
+PS_INSTALL_AUTO=0 \
+PS_ERASE_DB=0 \
+PS_DEV_MODE=0 \
+PS_HOST_MODE=0 \
+PS_HANDLE_DYNAMIC_DOMAIN=0 \
+PS_FOLDER_ADMIN=admin \
+PS_FOLDER_INSTALL=install
 
 RUN apt-get update \
 	&& apt-get install -y libmcrypt-dev \
@@ -39,6 +38,8 @@ RUN docker-php-source extract \
 	&& if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \
 	&& if [ -d "/usr/src/php/ext/opcache" ]; then docker-php-ext-install opcache; fi \
 	&& docker-php-source delete
+
+ENV PS_VERSION {PS_VERSION}
 
 # Get PrestaShop
 ADD {PS_URL} /tmp/prestashop.zip

--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -3,19 +3,20 @@ LABEL 'maintainer="Thomas Nabord <thomas.nabord@prestashop.com>"'
 
 ENV PS_DOMAIN <to be defined> \
 DB_SERVER <to be defined> \
-DB_PORT 3306  \
-DB_NAME prestashop  \
-DB_USER root  \
-DB_PASSWD admin  \
-ADMIN_MAIL demo@prestashop.com  \
-ADMIN_PASSWD prestashop_demo  \
-PS_LANGUAGE en  \
-PS_COUNTRY gb  \
-PS_INSTALL_AUTO 0  \
-PS_DEV_MODE 0  \
-PS_HOST_MODE 0  \
-PS_HANDLE_DYNAMIC_DOMAIN 0  \
-PS_FOLDER_ADMIN admin  \
+DB_PORT 3306 \
+DB_NAME prestashop \
+DB_USER root \
+DB_PASSWD admin \
+ADMIN_MAIL demo@prestashop.com \
+ADMIN_PASSWD prestashop_demo \
+PS_LANGUAGE en  
+PS_COUNTRY gb \
+PS_INSTALL_AUTO 0 \
+PS_ERASE_MYSQL 0 \
+PS_DEV_MODE 0 \
+PS_HOST_MODE 0 \
+PS_HANDLE_DYNAMIC_DOMAIN 0 \
+PS_FOLDER_ADMIN admin \
 PS_FOLDER_INSTALL install \
 PS_VERSION {PS_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ However, if you want to customize the container execution, here are many availab
 * **DB_PREFIX**: Override default tables prefix *(default value: ps_)*
 * **DB_NAME**: Override default database name *(default value: prestashop)*
 * **PS_INSTALL_AUTO=1**: The installation will be executed. Useful to initialize your image faster. In some configurations, you may need to set **PS_DOMAIN** or **PS_HANDLE_DYNAMIC_DOMAIN** as well. (Please note that PrestaShop can be installed automatically from PS 1.5)
-* **PS_DOMAIN**: When installing automatically your shop, you can tell the shop how it will be reached. For advanced users only. *(no default value)*
+* **PS_ERASE_MYSQL**: Only with **PS_INSTALL_AUTO=1**. Drop and create the mysql database. All previous mysql data will be lost *(default value: 0)*
+* **PS_DOMAIN**: When installing automatically your shop, you can tell the shop how it will be reached. For advanced users only *(no default value)*
 * **PS_LANGUAGE**: Change the default language installed with PrestaShop *(default value: en)*
 * **PS_COUNTRY**: Change the default country installed with PrestaShop *(default value: gb)*
 * **PS_FOLDER_ADMIN**: Change the name of the `admin` folder *(default value: admin. But will be automatically changed later)*

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ However, if you want to customize the container execution, here are many availab
 * **DB_PREFIX**: Override default tables prefix *(default value: ps_)*
 * **DB_NAME**: Override default database name *(default value: prestashop)*
 * **PS_INSTALL_AUTO=1**: The installation will be executed. Useful to initialize your image faster. In some configurations, you may need to set **PS_DOMAIN** or **PS_HANDLE_DYNAMIC_DOMAIN** as well. (Please note that PrestaShop can be installed automatically from PS 1.5)
-* **PS_ERASE_MYSQL**: Only with **PS_INSTALL_AUTO=1**. Drop and create the mysql database. All previous mysql data will be lost *(default value: 0)*
+* **PS_ERASE_DB**: Only with **PS_INSTALL_AUTO=1**. Drop and create the mysql database. All previous mysql data will be lost *(default value: 0)*
 * **PS_DOMAIN**: When installing automatically your shop, you can tell the shop how it will be reached. For advanced users only *(no default value)*
 * **PS_LANGUAGE**: Change the default language installed with PrestaShop *(default value: en)*
 * **PS_COUNTRY**: Change the default country installed with PrestaShop *(default value: gb)*

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -62,7 +62,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
-		if [ $PS_ERASE_MYSQL = 1 ]; then
+		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -6,9 +6,23 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
+# init if empty
+for dockervol in modules themes override; do
+    # maybe protect dir with space into name ?
+    if [ ! -f /var/www/${dockervol}/index.php  ]; then
+	echo "\n* Reapplying PrestaShop volume ${dockervol}";
+        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
+	chown www-data:www-data -R /var/www/${dockervol}/
+    else
+         echo "\n* Pretashop ${dockervol} already installed...";
+    fi
+done
+
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
-	bash /tmp/ps-extractor.sh /tmp/data-ps
+
+	# init if empty
+	cp -n -R /tmp/data-ps/prestashop/* /var/www/html
 
 	if [ $PS_DEV_MODE -ne 0 ]; then
 		echo "\n* Enabling DEV mode ...";
@@ -67,6 +81,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	fi
 
 	chown www-data:www-data -R /var/www/html/
+else
+    echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting Apache now\n";

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -62,14 +62,17 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
-		if [ $DB_PASSWD = "" ]; then
-			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
-		else
-			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-			mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+		if [ $PS_ERASE_MYSQL = 1 ]; then
+			echo "\n* Drop & recreate mysql database...";
+			if [ $DB_PASSWD = "" ]; then
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+			else
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+			fi
 		fi
-
+	
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/config_files/ps-extractor.sh
+++ b/config_files/ps-extractor.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 
 folder=$1
-destination="/var/www/html"
 
-if [[ -n "$folder" ]]; then
-    if [ -d $folder/prestashop ]; then
-        cp -n -R $folder/prestashop/* $destination
-    else
-        unzip -n -q $folder/prestashop.zip -d $destination
+if [[ -n "$folder" ]]; then  
+
+    # dwl version contains zip file with tree structure (1.7)
+    if [ ! -d $folder/prestashop ]; then
+        unzip -n -q $folder/prestashop.zip -d $folder/prestashop
+	rm -rf $folder/prestashop.zip	
     fi
+
+    # prepair tree structure for volumes
+    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
+
+    # build relative symlinks for volumes
+    ln -s ../themes $folder/prestashop/themes
+    ln -s ../modules $folder/prestashop/modules
+    ln -s ../override $folder/prestashop/override
 else
     echo "Missing folder to move"
 fi


### PR DESCRIPTION
Change the way of managing volumes :
- a copy of original prestashop core is always in /tmp/data-ps
- the CMD script copies the files and run install ONLY if the core and volumes are not initialized.

In case of recreating container (without changing data), the data and the code are not erased :)