### PR TITLE
Test that index.php file exists on boot (and during builds as well)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
 script:
   - docker build -t "$image" .
   - ~/official-images/test/run.sh "$image"
+  - docker run -tid --name prestashop $image && docker exec -ti prestashop cat /var/www/html/index.php
 
 after_script:
   - docker images

--- a/config_files/ps-extractor.sh
+++ b/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.1/config_files/ps-extractor.sh
+++ b/images/1.4.0.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.10/config_files/ps-extractor.sh
+++ b/images/1.4.0.10/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.11/config_files/ps-extractor.sh
+++ b/images/1.4.0.11/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.12/config_files/ps-extractor.sh
+++ b/images/1.4.0.12/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.13/config_files/ps-extractor.sh
+++ b/images/1.4.0.13/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.14/config_files/ps-extractor.sh
+++ b/images/1.4.0.14/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.17/config_files/ps-extractor.sh
+++ b/images/1.4.0.17/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.2/config_files/ps-extractor.sh
+++ b/images/1.4.0.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.3/config_files/ps-extractor.sh
+++ b/images/1.4.0.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.4/config_files/ps-extractor.sh
+++ b/images/1.4.0.4/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.5/config_files/ps-extractor.sh
+++ b/images/1.4.0.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.6/config_files/ps-extractor.sh
+++ b/images/1.4.0.6/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.7/config_files/ps-extractor.sh
+++ b/images/1.4.0.7/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.8/config_files/ps-extractor.sh
+++ b/images/1.4.0.8/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.0.9/config_files/ps-extractor.sh
+++ b/images/1.4.0.9/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.1.0/config_files/ps-extractor.sh
+++ b/images/1.4.1.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.10.0/config_files/ps-extractor.sh
+++ b/images/1.4.10.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.11.0/config_files/ps-extractor.sh
+++ b/images/1.4.11.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.11.1/config_files/ps-extractor.sh
+++ b/images/1.4.11.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.2.5/config_files/ps-extractor.sh
+++ b/images/1.4.2.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.3.0/config_files/ps-extractor.sh
+++ b/images/1.4.3.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.4.0/config_files/ps-extractor.sh
+++ b/images/1.4.4.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.4.1/config_files/ps-extractor.sh
+++ b/images/1.4.4.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.5.1/config_files/ps-extractor.sh
+++ b/images/1.4.5.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.6.1/config_files/ps-extractor.sh
+++ b/images/1.4.6.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.6.2/config_files/ps-extractor.sh
+++ b/images/1.4.6.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.7.0/config_files/ps-extractor.sh
+++ b/images/1.4.7.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.7.2/config_files/ps-extractor.sh
+++ b/images/1.4.7.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.7.3/config_files/ps-extractor.sh
+++ b/images/1.4.7.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.8.2/config_files/ps-extractor.sh
+++ b/images/1.4.8.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.8.3/config_files/ps-extractor.sh
+++ b/images/1.4.8.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.4.9.0/config_files/ps-extractor.sh
+++ b/images/1.4.9.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5-5.5/config_files/ps-extractor.sh
+++ b/images/1.5-5.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5-7.0/config_files/ps-extractor.sh
+++ b/images/1.5-7.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.1/config_files/ps-extractor.sh
+++ b/images/1.5.0.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.13/config_files/ps-extractor.sh
+++ b/images/1.5.0.13/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.15/config_files/ps-extractor.sh
+++ b/images/1.5.0.15/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.17/config_files/ps-extractor.sh
+++ b/images/1.5.0.17/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.2/config_files/ps-extractor.sh
+++ b/images/1.5.0.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.3/config_files/ps-extractor.sh
+++ b/images/1.5.0.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.5/config_files/ps-extractor.sh
+++ b/images/1.5.0.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.0.9/config_files/ps-extractor.sh
+++ b/images/1.5.0.9/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.1.0/config_files/ps-extractor.sh
+++ b/images/1.5.1.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.2.0/config_files/ps-extractor.sh
+++ b/images/1.5.2.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.3.0/config_files/ps-extractor.sh
+++ b/images/1.5.3.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.3.1/config_files/ps-extractor.sh
+++ b/images/1.5.3.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.4.0/config_files/ps-extractor.sh
+++ b/images/1.5.4.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.4.1/config_files/ps-extractor.sh
+++ b/images/1.5.4.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.5.0/config_files/ps-extractor.sh
+++ b/images/1.5.5.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.6.0/config_files/ps-extractor.sh
+++ b/images/1.5.6.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.6.1/config_files/ps-extractor.sh
+++ b/images/1.5.6.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.6.2/config_files/ps-extractor.sh
+++ b/images/1.5.6.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.5.6.3/config_files/ps-extractor.sh
+++ b/images/1.5.6.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6-5.5/config_files/ps-extractor.sh
+++ b/images/1.6-5.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6-7.0/config_files/ps-extractor.sh
+++ b/images/1.6-7.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.1/config_files/ps-extractor.sh
+++ b/images/1.6.0.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.11/config_files/ps-extractor.sh
+++ b/images/1.6.0.11/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.12/config_files/ps-extractor.sh
+++ b/images/1.6.0.12/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.13/config_files/ps-extractor.sh
+++ b/images/1.6.0.13/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.14/config_files/ps-extractor.sh
+++ b/images/1.6.0.14/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.2/config_files/ps-extractor.sh
+++ b/images/1.6.0.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.3/config_files/ps-extractor.sh
+++ b/images/1.6.0.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.4/config_files/ps-extractor.sh
+++ b/images/1.6.0.4/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.5/config_files/ps-extractor.sh
+++ b/images/1.6.0.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.6/config_files/ps-extractor.sh
+++ b/images/1.6.0.6/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.7/config_files/ps-extractor.sh
+++ b/images/1.6.0.7/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.8/config_files/ps-extractor.sh
+++ b/images/1.6.0.8/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.0.9/config_files/ps-extractor.sh
+++ b/images/1.6.0.9/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.0/config_files/ps-extractor.sh
+++ b/images/1.6.1.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.1/config_files/ps-extractor.sh
+++ b/images/1.6.1.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.10/config_files/ps-extractor.sh
+++ b/images/1.6.1.10/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.11/config_files/ps-extractor.sh
+++ b/images/1.6.1.11/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.12/config_files/ps-extractor.sh
+++ b/images/1.6.1.12/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.13/config_files/ps-extractor.sh
+++ b/images/1.6.1.13/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.14/config_files/ps-extractor.sh
+++ b/images/1.6.1.14/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.15/config_files/ps-extractor.sh
+++ b/images/1.6.1.15/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.16/config_files/ps-extractor.sh
+++ b/images/1.6.1.16/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.2/config_files/ps-extractor.sh
+++ b/images/1.6.1.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.3/config_files/ps-extractor.sh
+++ b/images/1.6.1.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.4/config_files/ps-extractor.sh
+++ b/images/1.6.1.4/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.5/config_files/ps-extractor.sh
+++ b/images/1.6.1.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.6/config_files/ps-extractor.sh
+++ b/images/1.6.1.6/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.7/config_files/ps-extractor.sh
+++ b/images/1.6.1.7/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.8/config_files/ps-extractor.sh
+++ b/images/1.6.1.8/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.6.1.9/config_files/ps-extractor.sh
+++ b/images/1.6.1.9/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7-5.5/config_files/ps-extractor.sh
+++ b/images/1.7-5.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7-7.0/config_files/ps-extractor.sh
+++ b/images/1.7-7.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.0/config_files/ps-extractor.sh
+++ b/images/1.7.0.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.1/config_files/ps-extractor.sh
+++ b/images/1.7.0.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.2/config_files/ps-extractor.sh
+++ b/images/1.7.0.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.3/config_files/ps-extractor.sh
+++ b/images/1.7.0.3/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.4/config_files/ps-extractor.sh
+++ b/images/1.7.0.4/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.5/config_files/ps-extractor.sh
+++ b/images/1.7.0.5/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.0.6/config_files/ps-extractor.sh
+++ b/images/1.7.0.6/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.1.0/config_files/ps-extractor.sh
+++ b/images/1.7.1.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.1.1/config_files/ps-extractor.sh
+++ b/images/1.7.1.1/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.1.2/config_files/ps-extractor.sh
+++ b/images/1.7.1.2/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi

--- a/images/1.7.2.0/config_files/ps-extractor.sh
+++ b/images/1.7.2.0/config_files/ps-extractor.sh
@@ -2,12 +2,12 @@
 
 folder=$1
 
-if [[ -n "$folder" ]]; then  
+if [[ -n "$folder" ]]; then
 
     # dwl version contains zip file with tree structure (1.7)
     if [ ! -d $folder/prestashop ]; then
         unzip -n -q $folder/prestashop.zip -d $folder/prestashop
-	rm -rf $folder/prestashop.zip	
+        rm -rf $folder/prestashop.zip
     fi
 
     # prepair tree structure for volumes
@@ -17,6 +17,8 @@ if [[ -n "$folder" ]]; then
     ln -s ../themes $folder/prestashop/themes
     ln -s ../modules $folder/prestashop/modules
     ln -s ../override $folder/prestashop/override
+
+    cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"
 fi


### PR DESCRIPTION
When we run additional build layers on the original PrestaShop image, we may require to modify some files. With the PR #83, the files becomes available only after a few seconds of run. This means that if you build `FROM prestashop/prestashop:x.x.x.x`, you do not have the PHP files yet.

This PR fixes the issue.