### PR TITLE
Remove volumes

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/config_files/ps-extractor.sh
+++ b/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.1/Dockerfile
+++ b/images/1.4.0.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.1/config_files/docker_run.sh
+++ b/images/1.4.0.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.1/config_files/ps-extractor.sh
+++ b/images/1.4.0.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.10/Dockerfile
+++ b/images/1.4.0.10/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.10/config_files/docker_run.sh
+++ b/images/1.4.0.10/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.10/config_files/ps-extractor.sh
+++ b/images/1.4.0.10/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.11/Dockerfile
+++ b/images/1.4.0.11/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.11/config_files/docker_run.sh
+++ b/images/1.4.0.11/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.11/config_files/ps-extractor.sh
+++ b/images/1.4.0.11/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.12/Dockerfile
+++ b/images/1.4.0.12/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.12/config_files/docker_run.sh
+++ b/images/1.4.0.12/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.12/config_files/ps-extractor.sh
+++ b/images/1.4.0.12/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.13/Dockerfile
+++ b/images/1.4.0.13/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.13/config_files/docker_run.sh
+++ b/images/1.4.0.13/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.13/config_files/ps-extractor.sh
+++ b/images/1.4.0.13/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.14/Dockerfile
+++ b/images/1.4.0.14/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.14/config_files/docker_run.sh
+++ b/images/1.4.0.14/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.14/config_files/ps-extractor.sh
+++ b/images/1.4.0.14/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.17/Dockerfile
+++ b/images/1.4.0.17/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.17/config_files/docker_run.sh
+++ b/images/1.4.0.17/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.17/config_files/ps-extractor.sh
+++ b/images/1.4.0.17/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.2/Dockerfile
+++ b/images/1.4.0.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.2/config_files/docker_run.sh
+++ b/images/1.4.0.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.2/config_files/ps-extractor.sh
+++ b/images/1.4.0.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.3/Dockerfile
+++ b/images/1.4.0.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.3/config_files/docker_run.sh
+++ b/images/1.4.0.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.3/config_files/ps-extractor.sh
+++ b/images/1.4.0.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.4/Dockerfile
+++ b/images/1.4.0.4/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.4/config_files/docker_run.sh
+++ b/images/1.4.0.4/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.4/config_files/ps-extractor.sh
+++ b/images/1.4.0.4/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.5/Dockerfile
+++ b/images/1.4.0.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.5/config_files/docker_run.sh
+++ b/images/1.4.0.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.5/config_files/ps-extractor.sh
+++ b/images/1.4.0.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.6/Dockerfile
+++ b/images/1.4.0.6/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.6/config_files/docker_run.sh
+++ b/images/1.4.0.6/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.6/config_files/ps-extractor.sh
+++ b/images/1.4.0.6/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.7/Dockerfile
+++ b/images/1.4.0.7/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.7/config_files/docker_run.sh
+++ b/images/1.4.0.7/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.7/config_files/ps-extractor.sh
+++ b/images/1.4.0.7/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.8/Dockerfile
+++ b/images/1.4.0.8/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.8/config_files/docker_run.sh
+++ b/images/1.4.0.8/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.8/config_files/ps-extractor.sh
+++ b/images/1.4.0.8/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.0.9/Dockerfile
+++ b/images/1.4.0.9/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.9/config_files/docker_run.sh
+++ b/images/1.4.0.9/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.0.9/config_files/ps-extractor.sh
+++ b/images/1.4.0.9/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.1.0/Dockerfile
+++ b/images/1.4.1.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.1.0/config_files/docker_run.sh
+++ b/images/1.4.1.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.1.0/config_files/ps-extractor.sh
+++ b/images/1.4.1.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.10.0/Dockerfile
+++ b/images/1.4.10.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.10.0/config_files/docker_run.sh
+++ b/images/1.4.10.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.10.0/config_files/ps-extractor.sh
+++ b/images/1.4.10.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.11.0/Dockerfile
+++ b/images/1.4.11.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.11.0/config_files/docker_run.sh
+++ b/images/1.4.11.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.11.0/config_files/ps-extractor.sh
+++ b/images/1.4.11.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.11.1/Dockerfile
+++ b/images/1.4.11.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.11.1/config_files/docker_run.sh
+++ b/images/1.4.11.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.11.1/config_files/ps-extractor.sh
+++ b/images/1.4.11.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.2.5/Dockerfile
+++ b/images/1.4.2.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.2.5/config_files/docker_run.sh
+++ b/images/1.4.2.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.2.5/config_files/ps-extractor.sh
+++ b/images/1.4.2.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.3.0/Dockerfile
+++ b/images/1.4.3.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.3.0/config_files/docker_run.sh
+++ b/images/1.4.3.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.3.0/config_files/ps-extractor.sh
+++ b/images/1.4.3.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.4.0/Dockerfile
+++ b/images/1.4.4.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.4.0/config_files/docker_run.sh
+++ b/images/1.4.4.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.4.0/config_files/ps-extractor.sh
+++ b/images/1.4.4.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.4.1/Dockerfile
+++ b/images/1.4.4.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.4.1/config_files/docker_run.sh
+++ b/images/1.4.4.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.4.1/config_files/ps-extractor.sh
+++ b/images/1.4.4.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.5.1/Dockerfile
+++ b/images/1.4.5.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.5.1/config_files/docker_run.sh
+++ b/images/1.4.5.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.5.1/config_files/ps-extractor.sh
+++ b/images/1.4.5.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.6.1/Dockerfile
+++ b/images/1.4.6.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.6.1/config_files/docker_run.sh
+++ b/images/1.4.6.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.6.1/config_files/ps-extractor.sh
+++ b/images/1.4.6.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.6.2/Dockerfile
+++ b/images/1.4.6.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.6.2/config_files/docker_run.sh
+++ b/images/1.4.6.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.6.2/config_files/ps-extractor.sh
+++ b/images/1.4.6.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.7.0/Dockerfile
+++ b/images/1.4.7.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.0/config_files/docker_run.sh
+++ b/images/1.4.7.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.7.0/config_files/ps-extractor.sh
+++ b/images/1.4.7.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.7.2/Dockerfile
+++ b/images/1.4.7.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.2/config_files/docker_run.sh
+++ b/images/1.4.7.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.7.2/config_files/ps-extractor.sh
+++ b/images/1.4.7.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.7.3/Dockerfile
+++ b/images/1.4.7.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.3/config_files/docker_run.sh
+++ b/images/1.4.7.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.7.3/config_files/ps-extractor.sh
+++ b/images/1.4.7.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.8.2/Dockerfile
+++ b/images/1.4.8.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.8.2/config_files/docker_run.sh
+++ b/images/1.4.8.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.8.2/config_files/ps-extractor.sh
+++ b/images/1.4.8.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.8.3/Dockerfile
+++ b/images/1.4.8.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.8.3/config_files/docker_run.sh
+++ b/images/1.4.8.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.8.3/config_files/ps-extractor.sh
+++ b/images/1.4.8.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.4.9.0/Dockerfile
+++ b/images/1.4.9.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.9.0/config_files/docker_run.sh
+++ b/images/1.4.9.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.4.9.0/config_files/ps-extractor.sh
+++ b/images/1.4.9.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5-5.5/Dockerfile
+++ b/images/1.5-5.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5-5.5/config_files/docker_run.sh
+++ b/images/1.5-5.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5-5.5/config_files/ps-extractor.sh
+++ b/images/1.5-5.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5-7.0/Dockerfile
+++ b/images/1.5-7.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5-7.0/config_files/docker_run.sh
+++ b/images/1.5-7.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5-7.0/config_files/ps-extractor.sh
+++ b/images/1.5-7.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.1/Dockerfile
+++ b/images/1.5.0.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.1/config_files/docker_run.sh
+++ b/images/1.5.0.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.1/config_files/ps-extractor.sh
+++ b/images/1.5.0.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.13/Dockerfile
+++ b/images/1.5.0.13/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.13/config_files/docker_run.sh
+++ b/images/1.5.0.13/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.13/config_files/ps-extractor.sh
+++ b/images/1.5.0.13/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.15/Dockerfile
+++ b/images/1.5.0.15/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.15/config_files/docker_run.sh
+++ b/images/1.5.0.15/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.15/config_files/ps-extractor.sh
+++ b/images/1.5.0.15/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.17/Dockerfile
+++ b/images/1.5.0.17/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.17/config_files/docker_run.sh
+++ b/images/1.5.0.17/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.17/config_files/ps-extractor.sh
+++ b/images/1.5.0.17/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.2/Dockerfile
+++ b/images/1.5.0.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.2/config_files/docker_run.sh
+++ b/images/1.5.0.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.2/config_files/ps-extractor.sh
+++ b/images/1.5.0.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.3/Dockerfile
+++ b/images/1.5.0.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.3/config_files/docker_run.sh
+++ b/images/1.5.0.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.3/config_files/ps-extractor.sh
+++ b/images/1.5.0.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.5/Dockerfile
+++ b/images/1.5.0.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.5/config_files/docker_run.sh
+++ b/images/1.5.0.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.5/config_files/ps-extractor.sh
+++ b/images/1.5.0.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.0.9/Dockerfile
+++ b/images/1.5.0.9/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.9/config_files/docker_run.sh
+++ b/images/1.5.0.9/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.0.9/config_files/ps-extractor.sh
+++ b/images/1.5.0.9/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.1.0/Dockerfile
+++ b/images/1.5.1.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.1.0/config_files/docker_run.sh
+++ b/images/1.5.1.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.1.0/config_files/ps-extractor.sh
+++ b/images/1.5.1.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.2.0/Dockerfile
+++ b/images/1.5.2.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.2.0/config_files/docker_run.sh
+++ b/images/1.5.2.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.2.0/config_files/ps-extractor.sh
+++ b/images/1.5.2.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.3.0/Dockerfile
+++ b/images/1.5.3.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.3.0/config_files/docker_run.sh
+++ b/images/1.5.3.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.3.0/config_files/ps-extractor.sh
+++ b/images/1.5.3.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.3.1/Dockerfile
+++ b/images/1.5.3.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.3.1/config_files/docker_run.sh
+++ b/images/1.5.3.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.3.1/config_files/ps-extractor.sh
+++ b/images/1.5.3.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.4.0/Dockerfile
+++ b/images/1.5.4.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.4.0/config_files/docker_run.sh
+++ b/images/1.5.4.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.4.0/config_files/ps-extractor.sh
+++ b/images/1.5.4.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.4.1/Dockerfile
+++ b/images/1.5.4.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.4.1/config_files/docker_run.sh
+++ b/images/1.5.4.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.4.1/config_files/ps-extractor.sh
+++ b/images/1.5.4.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.5.0/Dockerfile
+++ b/images/1.5.5.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.5.0/config_files/docker_run.sh
+++ b/images/1.5.5.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.5.0/config_files/ps-extractor.sh
+++ b/images/1.5.5.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.6.0/Dockerfile
+++ b/images/1.5.6.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.0/config_files/docker_run.sh
+++ b/images/1.5.6.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.6.0/config_files/ps-extractor.sh
+++ b/images/1.5.6.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.6.1/Dockerfile
+++ b/images/1.5.6.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.1/config_files/docker_run.sh
+++ b/images/1.5.6.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.6.1/config_files/ps-extractor.sh
+++ b/images/1.5.6.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.6.2/Dockerfile
+++ b/images/1.5.6.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.2/config_files/docker_run.sh
+++ b/images/1.5.6.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.6.2/config_files/ps-extractor.sh
+++ b/images/1.5.6.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.5.6.3/Dockerfile
+++ b/images/1.5.6.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.3/config_files/docker_run.sh
+++ b/images/1.5.6.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.5.6.3/config_files/ps-extractor.sh
+++ b/images/1.5.6.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6-5.5/Dockerfile
+++ b/images/1.6-5.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6-5.5/config_files/docker_run.sh
+++ b/images/1.6-5.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6-5.5/config_files/ps-extractor.sh
+++ b/images/1.6-5.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6-7.0/Dockerfile
+++ b/images/1.6-7.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6-7.0/config_files/docker_run.sh
+++ b/images/1.6-7.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6-7.0/config_files/ps-extractor.sh
+++ b/images/1.6-7.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.1/Dockerfile
+++ b/images/1.6.0.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.1/config_files/docker_run.sh
+++ b/images/1.6.0.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.1/config_files/ps-extractor.sh
+++ b/images/1.6.0.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.11/Dockerfile
+++ b/images/1.6.0.11/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.11/config_files/docker_run.sh
+++ b/images/1.6.0.11/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.11/config_files/ps-extractor.sh
+++ b/images/1.6.0.11/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.12/Dockerfile
+++ b/images/1.6.0.12/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.12/config_files/docker_run.sh
+++ b/images/1.6.0.12/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.12/config_files/ps-extractor.sh
+++ b/images/1.6.0.12/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.13/Dockerfile
+++ b/images/1.6.0.13/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.13/config_files/docker_run.sh
+++ b/images/1.6.0.13/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.13/config_files/ps-extractor.sh
+++ b/images/1.6.0.13/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.14/Dockerfile
+++ b/images/1.6.0.14/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.14/config_files/docker_run.sh
+++ b/images/1.6.0.14/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.14/config_files/ps-extractor.sh
+++ b/images/1.6.0.14/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.2/Dockerfile
+++ b/images/1.6.0.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.2/config_files/docker_run.sh
+++ b/images/1.6.0.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.2/config_files/ps-extractor.sh
+++ b/images/1.6.0.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.3/Dockerfile
+++ b/images/1.6.0.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.3/config_files/docker_run.sh
+++ b/images/1.6.0.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.3/config_files/ps-extractor.sh
+++ b/images/1.6.0.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.4/Dockerfile
+++ b/images/1.6.0.4/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.4/config_files/docker_run.sh
+++ b/images/1.6.0.4/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.4/config_files/ps-extractor.sh
+++ b/images/1.6.0.4/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.5/Dockerfile
+++ b/images/1.6.0.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.5/config_files/docker_run.sh
+++ b/images/1.6.0.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.5/config_files/ps-extractor.sh
+++ b/images/1.6.0.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.6/Dockerfile
+++ b/images/1.6.0.6/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.6/config_files/docker_run.sh
+++ b/images/1.6.0.6/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.6/config_files/ps-extractor.sh
+++ b/images/1.6.0.6/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.7/Dockerfile
+++ b/images/1.6.0.7/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.7/config_files/docker_run.sh
+++ b/images/1.6.0.7/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.7/config_files/ps-extractor.sh
+++ b/images/1.6.0.7/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.8/Dockerfile
+++ b/images/1.6.0.8/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.8/config_files/docker_run.sh
+++ b/images/1.6.0.8/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.8/config_files/ps-extractor.sh
+++ b/images/1.6.0.8/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.0.9/Dockerfile
+++ b/images/1.6.0.9/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.9/config_files/docker_run.sh
+++ b/images/1.6.0.9/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.0.9/config_files/ps-extractor.sh
+++ b/images/1.6.0.9/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.0/Dockerfile
+++ b/images/1.6.1.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.0/config_files/docker_run.sh
+++ b/images/1.6.1.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.0/config_files/ps-extractor.sh
+++ b/images/1.6.1.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.1/Dockerfile
+++ b/images/1.6.1.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.1/config_files/docker_run.sh
+++ b/images/1.6.1.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.1/config_files/ps-extractor.sh
+++ b/images/1.6.1.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.10/Dockerfile
+++ b/images/1.6.1.10/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.10/config_files/docker_run.sh
+++ b/images/1.6.1.10/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.10/config_files/ps-extractor.sh
+++ b/images/1.6.1.10/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.11/Dockerfile
+++ b/images/1.6.1.11/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.11/config_files/docker_run.sh
+++ b/images/1.6.1.11/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.11/config_files/ps-extractor.sh
+++ b/images/1.6.1.11/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.12/Dockerfile
+++ b/images/1.6.1.12/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.12/config_files/docker_run.sh
+++ b/images/1.6.1.12/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.12/config_files/ps-extractor.sh
+++ b/images/1.6.1.12/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.13/Dockerfile
+++ b/images/1.6.1.13/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.13/config_files/docker_run.sh
+++ b/images/1.6.1.13/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.13/config_files/ps-extractor.sh
+++ b/images/1.6.1.13/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.14/Dockerfile
+++ b/images/1.6.1.14/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.14/config_files/docker_run.sh
+++ b/images/1.6.1.14/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.14/config_files/ps-extractor.sh
+++ b/images/1.6.1.14/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.15/Dockerfile
+++ b/images/1.6.1.15/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.15/config_files/docker_run.sh
+++ b/images/1.6.1.15/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.15/config_files/ps-extractor.sh
+++ b/images/1.6.1.15/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.16/Dockerfile
+++ b/images/1.6.1.16/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.16/config_files/docker_run.sh
+++ b/images/1.6.1.16/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.16/config_files/ps-extractor.sh
+++ b/images/1.6.1.16/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.2/Dockerfile
+++ b/images/1.6.1.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.2/config_files/docker_run.sh
+++ b/images/1.6.1.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.2/config_files/ps-extractor.sh
+++ b/images/1.6.1.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.3/Dockerfile
+++ b/images/1.6.1.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.3/config_files/docker_run.sh
+++ b/images/1.6.1.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.3/config_files/ps-extractor.sh
+++ b/images/1.6.1.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.4/Dockerfile
+++ b/images/1.6.1.4/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.4/config_files/docker_run.sh
+++ b/images/1.6.1.4/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.4/config_files/ps-extractor.sh
+++ b/images/1.6.1.4/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.5/Dockerfile
+++ b/images/1.6.1.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.5/config_files/docker_run.sh
+++ b/images/1.6.1.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.5/config_files/ps-extractor.sh
+++ b/images/1.6.1.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.6/Dockerfile
+++ b/images/1.6.1.6/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.6/config_files/docker_run.sh
+++ b/images/1.6.1.6/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.6/config_files/ps-extractor.sh
+++ b/images/1.6.1.6/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.7/Dockerfile
+++ b/images/1.6.1.7/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.7/config_files/docker_run.sh
+++ b/images/1.6.1.7/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.7/config_files/ps-extractor.sh
+++ b/images/1.6.1.7/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.8/Dockerfile
+++ b/images/1.6.1.8/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.8/config_files/docker_run.sh
+++ b/images/1.6.1.8/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.8/config_files/ps-extractor.sh
+++ b/images/1.6.1.8/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.6.1.9/Dockerfile
+++ b/images/1.6.1.9/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.9/config_files/docker_run.sh
+++ b/images/1.6.1.9/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.6.1.9/config_files/ps-extractor.sh
+++ b/images/1.6.1.9/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7-5.5/Dockerfile
+++ b/images/1.7-5.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7-5.5/config_files/docker_run.sh
+++ b/images/1.7-5.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7-5.5/config_files/ps-extractor.sh
+++ b/images/1.7-5.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7-7.0/Dockerfile
+++ b/images/1.7-7.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7-7.0/config_files/docker_run.sh
+++ b/images/1.7-7.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7-7.0/config_files/ps-extractor.sh
+++ b/images/1.7-7.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.0/Dockerfile
+++ b/images/1.7.0.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.0/config_files/docker_run.sh
+++ b/images/1.7.0.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.0/config_files/ps-extractor.sh
+++ b/images/1.7.0.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.1/Dockerfile
+++ b/images/1.7.0.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.1/config_files/docker_run.sh
+++ b/images/1.7.0.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.1/config_files/ps-extractor.sh
+++ b/images/1.7.0.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.2/Dockerfile
+++ b/images/1.7.0.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.2/config_files/docker_run.sh
+++ b/images/1.7.0.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.2/config_files/ps-extractor.sh
+++ b/images/1.7.0.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.3/Dockerfile
+++ b/images/1.7.0.3/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.3/config_files/docker_run.sh
+++ b/images/1.7.0.3/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.3/config_files/ps-extractor.sh
+++ b/images/1.7.0.3/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.4/Dockerfile
+++ b/images/1.7.0.4/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.4/config_files/docker_run.sh
+++ b/images/1.7.0.4/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.4/config_files/ps-extractor.sh
+++ b/images/1.7.0.4/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.5/Dockerfile
+++ b/images/1.7.0.5/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.5/config_files/docker_run.sh
+++ b/images/1.7.0.5/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.5/config_files/ps-extractor.sh
+++ b/images/1.7.0.5/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.0.6/Dockerfile
+++ b/images/1.7.0.6/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.6/config_files/docker_run.sh
+++ b/images/1.7.0.6/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.0.6/config_files/ps-extractor.sh
+++ b/images/1.7.0.6/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.1.0/Dockerfile
+++ b/images/1.7.1.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.0/config_files/docker_run.sh
+++ b/images/1.7.1.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.1.0/config_files/ps-extractor.sh
+++ b/images/1.7.1.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.1.1/Dockerfile
+++ b/images/1.7.1.1/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.1/config_files/docker_run.sh
+++ b/images/1.7.1.1/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.1.1/config_files/ps-extractor.sh
+++ b/images/1.7.1.1/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.1.2/Dockerfile
+++ b/images/1.7.1.2/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.2/config_files/docker_run.sh
+++ b/images/1.7.1.2/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.1.2/config_files/ps-extractor.sh
+++ b/images/1.7.1.2/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"

--- a/images/1.7.2.0/Dockerfile
+++ b/images/1.7.2.0/Dockerfile
@@ -61,7 +61,7 @@ RUN a2enmod rewrite
 COPY config_files/php.ini /usr/local/etc/php/
 
 # Declare
-VOLUME ["/var/www/html","/var/www/modules","/var/www/themes","/var/www/override"]
+VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.2.0/config_files/docker_run.sh
+++ b/images/1.7.2.0/config_files/docker_run.sh
@@ -6,18 +6,6 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-# init if empty
-for dockervol in modules themes override; do
-    # maybe protect dir with space into name ?
-    if [ ! -f /var/www/${dockervol}/index.php  ]; then
-	echo "\n* Reapplying PrestaShop volume ${dockervol}";
-        cp -n -R /tmp/data-ps/${dockervol}/* /var/www/${dockervol}
-	chown www-data:www-data -R /var/www/${dockervol}/
-    else
-         echo "\n* Pretashop ${dockervol} already installed...";
-    fi
-done
-
 if [ ! -f ./config/settings.inc.php  ]; then
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -72,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
 			fi
 		fi
-	
+
 		if [ "$PS_DOMAIN" = "<to be defined>" ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi

--- a/images/1.7.2.0/config_files/ps-extractor.sh
+++ b/images/1.7.2.0/config_files/ps-extractor.sh
@@ -10,14 +10,6 @@ if [[ -n "$folder" ]]; then
         rm -rf $folder/prestashop.zip
     fi
 
-    # prepair tree structure for volumes
-    mv $folder/prestashop/themes $folder/prestashop/modules $folder/prestashop/override $folder/
-
-    # build relative symlinks for volumes
-    ln -s ../themes $folder/prestashop/themes
-    ln -s ../modules $folder/prestashop/modules
-    ln -s ../override $folder/prestashop/override
-
     cp -n -R $folder/prestashop/* /var/www/html
 else
     echo "Missing folder to move"


### PR DESCRIPTION
Unfortunately, having this volume management for subfolders of PrestaShop website brought many issues during build of other images.

I decided to remove all previous volumes and keep only one for the root folder of PrestaShop.

Sorry @khena, I know you made a hard work to handle both root and subfolders working as volumes, but it appears we have more issues than before.