### PR TITLE
Add missing DB_PREFIX variable

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -7,6 +7,7 @@ DB_PORT=3306 \
 DB_NAME=prestashop \
 DB_USER=root \
 DB_PASSWD=admin \
+DB_PREFIX=ps_ \
 ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -66,7 +66,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		fi
 
 		php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --firstname="John" --lastname="Doe" \
+			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
 			--newsletter=0 --send_email=0
 	fi


### PR DESCRIPTION
Hi,
According to the README, DB_PREFIX allow to set the table prefix into the database. But, it was not used anywhere in the docker build process. Here an attempt to fix that :-)