### PR TITLE
Cleanup

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.1/Dockerfile
+++ b/images/1.4.0.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.10/Dockerfile
+++ b/images/1.4.0.10/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.11/Dockerfile
+++ b/images/1.4.0.11/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.12/Dockerfile
+++ b/images/1.4.0.12/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.13/Dockerfile
+++ b/images/1.4.0.13/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.14/Dockerfile
+++ b/images/1.4.0.14/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.17/Dockerfile
+++ b/images/1.4.0.17/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.2/Dockerfile
+++ b/images/1.4.0.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.3/Dockerfile
+++ b/images/1.4.0.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.4/Dockerfile
+++ b/images/1.4.0.4/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.5/Dockerfile
+++ b/images/1.4.0.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.6/Dockerfile
+++ b/images/1.4.0.6/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.7/Dockerfile
+++ b/images/1.4.0.7/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.8/Dockerfile
+++ b/images/1.4.0.8/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.0.9/Dockerfile
+++ b/images/1.4.0.9/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.1.0/Dockerfile
+++ b/images/1.4.1.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.10.0/Dockerfile
+++ b/images/1.4.10.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.11.0/Dockerfile
+++ b/images/1.4.11.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.11.1/Dockerfile
+++ b/images/1.4.11.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.2.5/Dockerfile
+++ b/images/1.4.2.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.3.0/Dockerfile
+++ b/images/1.4.3.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.4.0/Dockerfile
+++ b/images/1.4.4.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.4.1/Dockerfile
+++ b/images/1.4.4.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.5.1/Dockerfile
+++ b/images/1.4.5.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.6.1/Dockerfile
+++ b/images/1.4.6.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.6.2/Dockerfile
+++ b/images/1.4.6.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.0/Dockerfile
+++ b/images/1.4.7.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.2/Dockerfile
+++ b/images/1.4.7.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.7.3/Dockerfile
+++ b/images/1.4.7.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.8.2/Dockerfile
+++ b/images/1.4.8.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.8.3/Dockerfile
+++ b/images/1.4.8.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.4.9.0/Dockerfile
+++ b/images/1.4.9.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5-5.5/Dockerfile
+++ b/images/1.5-5.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5-7.0/Dockerfile
+++ b/images/1.5-7.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.1/Dockerfile
+++ b/images/1.5.0.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.13/Dockerfile
+++ b/images/1.5.0.13/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.15/Dockerfile
+++ b/images/1.5.0.15/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.17/Dockerfile
+++ b/images/1.5.0.17/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.2/Dockerfile
+++ b/images/1.5.0.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.3/Dockerfile
+++ b/images/1.5.0.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.5/Dockerfile
+++ b/images/1.5.0.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.0.9/Dockerfile
+++ b/images/1.5.0.9/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.1.0/Dockerfile
+++ b/images/1.5.1.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.2.0/Dockerfile
+++ b/images/1.5.2.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.3.0/Dockerfile
+++ b/images/1.5.3.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.3.1/Dockerfile
+++ b/images/1.5.3.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.4.0/Dockerfile
+++ b/images/1.5.4.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.4.1/Dockerfile
+++ b/images/1.5.4.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.5.0/Dockerfile
+++ b/images/1.5.5.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.0/Dockerfile
+++ b/images/1.5.6.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.1/Dockerfile
+++ b/images/1.5.6.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.2/Dockerfile
+++ b/images/1.5.6.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.5.6.3/Dockerfile
+++ b/images/1.5.6.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6-5.5/Dockerfile
+++ b/images/1.6-5.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6-7.0/Dockerfile
+++ b/images/1.6-7.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.1/Dockerfile
+++ b/images/1.6.0.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.11/Dockerfile
+++ b/images/1.6.0.11/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.12/Dockerfile
+++ b/images/1.6.0.12/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.13/Dockerfile
+++ b/images/1.6.0.13/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.14/Dockerfile
+++ b/images/1.6.0.14/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.2/Dockerfile
+++ b/images/1.6.0.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.3/Dockerfile
+++ b/images/1.6.0.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.4/Dockerfile
+++ b/images/1.6.0.4/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.5/Dockerfile
+++ b/images/1.6.0.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.6/Dockerfile
+++ b/images/1.6.0.6/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.7/Dockerfile
+++ b/images/1.6.0.7/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.8/Dockerfile
+++ b/images/1.6.0.8/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.0.9/Dockerfile
+++ b/images/1.6.0.9/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.0/Dockerfile
+++ b/images/1.6.1.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.1/Dockerfile
+++ b/images/1.6.1.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.10/Dockerfile
+++ b/images/1.6.1.10/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.11/Dockerfile
+++ b/images/1.6.1.11/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.12/Dockerfile
+++ b/images/1.6.1.12/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.13/Dockerfile
+++ b/images/1.6.1.13/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.14/Dockerfile
+++ b/images/1.6.1.14/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.15/Dockerfile
+++ b/images/1.6.1.15/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.16/Dockerfile
+++ b/images/1.6.1.16/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.2/Dockerfile
+++ b/images/1.6.1.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.3/Dockerfile
+++ b/images/1.6.1.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.4/Dockerfile
+++ b/images/1.6.1.4/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.5/Dockerfile
+++ b/images/1.6.1.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.6/Dockerfile
+++ b/images/1.6.1.6/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.7/Dockerfile
+++ b/images/1.6.1.7/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.8/Dockerfile
+++ b/images/1.6.1.8/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.6.1.9/Dockerfile
+++ b/images/1.6.1.9/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7-5.5/Dockerfile
+++ b/images/1.7-5.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7-7.0/Dockerfile
+++ b/images/1.7-7.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.0/Dockerfile
+++ b/images/1.7.0.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.1/Dockerfile
+++ b/images/1.7.0.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.2/Dockerfile
+++ b/images/1.7.0.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.3/Dockerfile
+++ b/images/1.7.0.3/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.4/Dockerfile
+++ b/images/1.7.0.4/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.5/Dockerfile
+++ b/images/1.7.0.5/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.0.6/Dockerfile
+++ b/images/1.7.0.6/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.0/Dockerfile
+++ b/images/1.7.1.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.1/Dockerfile
+++ b/images/1.7.1.1/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.1.2/Dockerfile
+++ b/images/1.7.1.2/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]

--- a/images/1.7.2.0/Dockerfile
+++ b/images/1.7.2.0/Dockerfile
@@ -57,13 +57,9 @@ COPY config_files/docker_updt_ps_domains.php /var/www/html/
 
 # Apache configuration
 RUN a2enmod rewrite
-RUN chown www-data:www-data -R /var/www/html/
 
 # PHP configuration
 COPY config_files/php.ini /usr/local/etc/php/
-
-# Declare
-VOLUME ["/var/www/html"]
 
 # Run
 CMD ["/tmp/docker_run.sh"]


### PR DESCRIPTION
On https://github.com/moby/moby/issues/14385, I discovered that once a volume is created during a build, all its content cannot be modified during the next steps. This is an issue for cumulative builds supposed to install PrestaShop.

I remove the last volume written. Fortunately, it cannot prevent another volume declaration on docker run, and we keep the files copy.