### PR TITLE
Fix issue #102 when no handle dynamic domain

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/config_files/docker_run.sh
+++ b/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.1/Dockerfile
+++ b/images/1.4.0.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.1/config_files/docker_run.sh
+++ b/images/1.4.0.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.10/Dockerfile
+++ b/images/1.4.0.10/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.10/config_files/docker_run.sh
+++ b/images/1.4.0.10/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.11/Dockerfile
+++ b/images/1.4.0.11/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.11/config_files/docker_run.sh
+++ b/images/1.4.0.11/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.12/Dockerfile
+++ b/images/1.4.0.12/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.12/config_files/docker_run.sh
+++ b/images/1.4.0.12/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.13/Dockerfile
+++ b/images/1.4.0.13/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.13/config_files/docker_run.sh
+++ b/images/1.4.0.13/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.14/Dockerfile
+++ b/images/1.4.0.14/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.14/config_files/docker_run.sh
+++ b/images/1.4.0.14/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.17/Dockerfile
+++ b/images/1.4.0.17/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.17/config_files/docker_run.sh
+++ b/images/1.4.0.17/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.2/Dockerfile
+++ b/images/1.4.0.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.2/config_files/docker_run.sh
+++ b/images/1.4.0.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.3/Dockerfile
+++ b/images/1.4.0.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.3/config_files/docker_run.sh
+++ b/images/1.4.0.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.4/Dockerfile
+++ b/images/1.4.0.4/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.4/config_files/docker_run.sh
+++ b/images/1.4.0.4/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.5/Dockerfile
+++ b/images/1.4.0.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.5/config_files/docker_run.sh
+++ b/images/1.4.0.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.6/Dockerfile
+++ b/images/1.4.0.6/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.6/config_files/docker_run.sh
+++ b/images/1.4.0.6/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.7/Dockerfile
+++ b/images/1.4.0.7/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.7/config_files/docker_run.sh
+++ b/images/1.4.0.7/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.8/Dockerfile
+++ b/images/1.4.0.8/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.8/config_files/docker_run.sh
+++ b/images/1.4.0.8/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.0.9/Dockerfile
+++ b/images/1.4.0.9/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.0.9/config_files/docker_run.sh
+++ b/images/1.4.0.9/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.1.0/Dockerfile
+++ b/images/1.4.1.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.1.0/config_files/docker_run.sh
+++ b/images/1.4.1.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.10.0/Dockerfile
+++ b/images/1.4.10.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.10.0/config_files/docker_run.sh
+++ b/images/1.4.10.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.11.0/Dockerfile
+++ b/images/1.4.11.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.11.0/config_files/docker_run.sh
+++ b/images/1.4.11.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.11.1/Dockerfile
+++ b/images/1.4.11.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.11.1/config_files/docker_run.sh
+++ b/images/1.4.11.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.2.5/Dockerfile
+++ b/images/1.4.2.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.2.5/config_files/docker_run.sh
+++ b/images/1.4.2.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.3.0/Dockerfile
+++ b/images/1.4.3.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.3.0/config_files/docker_run.sh
+++ b/images/1.4.3.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.4.0/Dockerfile
+++ b/images/1.4.4.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.4.0/config_files/docker_run.sh
+++ b/images/1.4.4.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.4.1/Dockerfile
+++ b/images/1.4.4.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.4.1/config_files/docker_run.sh
+++ b/images/1.4.4.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.5.1/Dockerfile
+++ b/images/1.4.5.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.5.1/config_files/docker_run.sh
+++ b/images/1.4.5.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.6.1/Dockerfile
+++ b/images/1.4.6.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.6.1/config_files/docker_run.sh
+++ b/images/1.4.6.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.6.2/Dockerfile
+++ b/images/1.4.6.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.6.2/config_files/docker_run.sh
+++ b/images/1.4.6.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.7.0/Dockerfile
+++ b/images/1.4.7.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.7.0/config_files/docker_run.sh
+++ b/images/1.4.7.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.7.2/Dockerfile
+++ b/images/1.4.7.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.7.2/config_files/docker_run.sh
+++ b/images/1.4.7.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.7.3/Dockerfile
+++ b/images/1.4.7.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.7.3/config_files/docker_run.sh
+++ b/images/1.4.7.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.8.2/Dockerfile
+++ b/images/1.4.8.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.8.2/config_files/docker_run.sh
+++ b/images/1.4.8.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.8.3/Dockerfile
+++ b/images/1.4.8.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.8.3/config_files/docker_run.sh
+++ b/images/1.4.8.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.4.9.0/Dockerfile
+++ b/images/1.4.9.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.4.9.0/config_files/docker_run.sh
+++ b/images/1.4.9.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5-5.5/Dockerfile
+++ b/images/1.5-5.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5-5.5/config_files/docker_run.sh
+++ b/images/1.5-5.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5-7.0/Dockerfile
+++ b/images/1.5-7.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5-7.0/config_files/docker_run.sh
+++ b/images/1.5-7.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.1/Dockerfile
+++ b/images/1.5.0.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.1/config_files/docker_run.sh
+++ b/images/1.5.0.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.13/Dockerfile
+++ b/images/1.5.0.13/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.13/config_files/docker_run.sh
+++ b/images/1.5.0.13/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.15/Dockerfile
+++ b/images/1.5.0.15/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.15/config_files/docker_run.sh
+++ b/images/1.5.0.15/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.17/Dockerfile
+++ b/images/1.5.0.17/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.17/config_files/docker_run.sh
+++ b/images/1.5.0.17/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.2/Dockerfile
+++ b/images/1.5.0.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.2/config_files/docker_run.sh
+++ b/images/1.5.0.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.3/Dockerfile
+++ b/images/1.5.0.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.3/config_files/docker_run.sh
+++ b/images/1.5.0.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.5/Dockerfile
+++ b/images/1.5.0.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.5/config_files/docker_run.sh
+++ b/images/1.5.0.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.0.9/Dockerfile
+++ b/images/1.5.0.9/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.0.9/config_files/docker_run.sh
+++ b/images/1.5.0.9/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.1.0/Dockerfile
+++ b/images/1.5.1.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.1.0/config_files/docker_run.sh
+++ b/images/1.5.1.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.2.0/Dockerfile
+++ b/images/1.5.2.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.2.0/config_files/docker_run.sh
+++ b/images/1.5.2.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.3.0/Dockerfile
+++ b/images/1.5.3.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.3.0/config_files/docker_run.sh
+++ b/images/1.5.3.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.3.1/Dockerfile
+++ b/images/1.5.3.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.3.1/config_files/docker_run.sh
+++ b/images/1.5.3.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.4.0/Dockerfile
+++ b/images/1.5.4.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.4.0/config_files/docker_run.sh
+++ b/images/1.5.4.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.4.1/Dockerfile
+++ b/images/1.5.4.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.4.1/config_files/docker_run.sh
+++ b/images/1.5.4.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.5.0/Dockerfile
+++ b/images/1.5.5.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.5.0/config_files/docker_run.sh
+++ b/images/1.5.5.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.6.0/Dockerfile
+++ b/images/1.5.6.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.6.0/config_files/docker_run.sh
+++ b/images/1.5.6.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.6.1/Dockerfile
+++ b/images/1.5.6.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.6.1/config_files/docker_run.sh
+++ b/images/1.5.6.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.6.2/Dockerfile
+++ b/images/1.5.6.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.6.2/config_files/docker_run.sh
+++ b/images/1.5.6.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.5.6.3/Dockerfile
+++ b/images/1.5.6.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.5.6.3/config_files/docker_run.sh
+++ b/images/1.5.6.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6-5.5/Dockerfile
+++ b/images/1.6-5.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6-5.5/config_files/docker_run.sh
+++ b/images/1.6-5.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6-7.0/Dockerfile
+++ b/images/1.6-7.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6-7.0/config_files/docker_run.sh
+++ b/images/1.6-7.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.1/Dockerfile
+++ b/images/1.6.0.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.1/config_files/docker_run.sh
+++ b/images/1.6.0.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.11/Dockerfile
+++ b/images/1.6.0.11/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.11/config_files/docker_run.sh
+++ b/images/1.6.0.11/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.12/Dockerfile
+++ b/images/1.6.0.12/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.12/config_files/docker_run.sh
+++ b/images/1.6.0.12/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.13/Dockerfile
+++ b/images/1.6.0.13/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.13/config_files/docker_run.sh
+++ b/images/1.6.0.13/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.14/Dockerfile
+++ b/images/1.6.0.14/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.14/config_files/docker_run.sh
+++ b/images/1.6.0.14/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.2/Dockerfile
+++ b/images/1.6.0.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.2/config_files/docker_run.sh
+++ b/images/1.6.0.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.3/Dockerfile
+++ b/images/1.6.0.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.3/config_files/docker_run.sh
+++ b/images/1.6.0.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.4/Dockerfile
+++ b/images/1.6.0.4/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.4/config_files/docker_run.sh
+++ b/images/1.6.0.4/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.5/Dockerfile
+++ b/images/1.6.0.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.5/config_files/docker_run.sh
+++ b/images/1.6.0.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.6/Dockerfile
+++ b/images/1.6.0.6/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.6/config_files/docker_run.sh
+++ b/images/1.6.0.6/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.7/Dockerfile
+++ b/images/1.6.0.7/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.7/config_files/docker_run.sh
+++ b/images/1.6.0.7/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.8/Dockerfile
+++ b/images/1.6.0.8/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.8/config_files/docker_run.sh
+++ b/images/1.6.0.8/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.0.9/Dockerfile
+++ b/images/1.6.0.9/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.0.9/config_files/docker_run.sh
+++ b/images/1.6.0.9/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.0/Dockerfile
+++ b/images/1.6.1.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.0/config_files/docker_run.sh
+++ b/images/1.6.1.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.1/Dockerfile
+++ b/images/1.6.1.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.1/config_files/docker_run.sh
+++ b/images/1.6.1.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.10/Dockerfile
+++ b/images/1.6.1.10/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.10/config_files/docker_run.sh
+++ b/images/1.6.1.10/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.11/Dockerfile
+++ b/images/1.6.1.11/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.11/config_files/docker_run.sh
+++ b/images/1.6.1.11/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.12/Dockerfile
+++ b/images/1.6.1.12/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.12/config_files/docker_run.sh
+++ b/images/1.6.1.12/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.13/Dockerfile
+++ b/images/1.6.1.13/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.13/config_files/docker_run.sh
+++ b/images/1.6.1.13/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.14/Dockerfile
+++ b/images/1.6.1.14/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.14/config_files/docker_run.sh
+++ b/images/1.6.1.14/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.15/Dockerfile
+++ b/images/1.6.1.15/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.15/config_files/docker_run.sh
+++ b/images/1.6.1.15/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.16/Dockerfile
+++ b/images/1.6.1.16/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.16/config_files/docker_run.sh
+++ b/images/1.6.1.16/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.17/Dockerfile
+++ b/images/1.6.1.17/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.17/config_files/docker_run.sh
+++ b/images/1.6.1.17/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.2/Dockerfile
+++ b/images/1.6.1.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.2/config_files/docker_run.sh
+++ b/images/1.6.1.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.3/Dockerfile
+++ b/images/1.6.1.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.3/config_files/docker_run.sh
+++ b/images/1.6.1.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.4/Dockerfile
+++ b/images/1.6.1.4/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.4/config_files/docker_run.sh
+++ b/images/1.6.1.4/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.5/Dockerfile
+++ b/images/1.6.1.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.5/config_files/docker_run.sh
+++ b/images/1.6.1.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.6/Dockerfile
+++ b/images/1.6.1.6/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.6/config_files/docker_run.sh
+++ b/images/1.6.1.6/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.7/Dockerfile
+++ b/images/1.6.1.7/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.7/config_files/docker_run.sh
+++ b/images/1.6.1.7/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.8/Dockerfile
+++ b/images/1.6.1.8/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.8/config_files/docker_run.sh
+++ b/images/1.6.1.8/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.6.1.9/Dockerfile
+++ b/images/1.6.1.9/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.6.1.9/config_files/docker_run.sh
+++ b/images/1.6.1.9/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7-5.5/Dockerfile
+++ b/images/1.7-5.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7-5.5/config_files/docker_run.sh
+++ b/images/1.7-5.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7-7.0/Dockerfile
+++ b/images/1.7-7.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7-7.0/config_files/docker_run.sh
+++ b/images/1.7-7.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.0/Dockerfile
+++ b/images/1.7.0.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.0/config_files/docker_run.sh
+++ b/images/1.7.0.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.1/Dockerfile
+++ b/images/1.7.0.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.1/config_files/docker_run.sh
+++ b/images/1.7.0.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.2/Dockerfile
+++ b/images/1.7.0.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.2/config_files/docker_run.sh
+++ b/images/1.7.0.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.3/Dockerfile
+++ b/images/1.7.0.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.3/config_files/docker_run.sh
+++ b/images/1.7.0.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.4/Dockerfile
+++ b/images/1.7.0.4/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.4/config_files/docker_run.sh
+++ b/images/1.7.0.4/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.5/Dockerfile
+++ b/images/1.7.0.5/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.5/config_files/docker_run.sh
+++ b/images/1.7.0.5/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.0.6/Dockerfile
+++ b/images/1.7.0.6/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.0.6/config_files/docker_run.sh
+++ b/images/1.7.0.6/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.1.0/Dockerfile
+++ b/images/1.7.1.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.1.0/config_files/docker_run.sh
+++ b/images/1.7.1.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.1.1/Dockerfile
+++ b/images/1.7.1.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.1.1/config_files/docker_run.sh
+++ b/images/1.7.1.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.1.2/Dockerfile
+++ b/images/1.7.1.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.1.2/config_files/docker_run.sh
+++ b/images/1.7.1.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.2.0/Dockerfile
+++ b/images/1.7.2.0/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.2.0/config_files/docker_run.sh
+++ b/images/1.7.2.0/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.2.1/Dockerfile
+++ b/images/1.7.2.1/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.2.1/config_files/docker_run.sh
+++ b/images/1.7.2.1/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.2.2/Dockerfile
+++ b/images/1.7.2.2/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.2.2/config_files/docker_run.sh
+++ b/images/1.7.2.2/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.2.3/Dockerfile
+++ b/images/1.7.2.3/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.2.3/config_files/docker_run.sh
+++ b/images/1.7.2.3/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 

--- a/images/1.7.2.4/Dockerfile
+++ b/images/1.7.2.4/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /tmp/data-ps /var/www/modules /var/www/themes /var/www/override \
 	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
 	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
 	&& rm /tmp/prestashop.zip
-COPY config_files/docker_updt_ps_domains.php /var/www/html/
+
+# If handle dynamic domain
+COPY config_files/docker_updt_ps_domains.php /tmp/
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/images/1.7.2.4/config_files/docker_run.sh
+++ b/images/1.7.2.4/config_files/docker_run.sh
@@ -32,9 +32,8 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		mv /var/www/html/admin /var/www/html/$PS_FOLDER_ADMIN/
 	fi
 
-	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 0 ]; then
-		rm /var/www/html/docker_updt_ps_domains.php
-	else
+	if [ $PS_HANDLE_DYNAMIC_DOMAIN = 1 ]; then
+		cp /tmp/docker_updt_ps_domains.php /var/www/html
 		sed -ie "s/DirectoryIndex\ index.php\ index.html/DirectoryIndex\ docker_updt_ps_domains.php\ index.php\ index.html/g" $APACHE_CONFDIR/conf-available/docker-php.conf
 	fi
 


### PR DESCRIPTION
As mentioned in #102, you have to deal with the docker_updt_ps_domains.php file when you enable the PS_HANDLE_DYNAMIC_DOMAIN option, otherwise it creates an unnecessary error when you use a volume