### PR TITLE
Add libzip package to the base image

### DIFF
--- a/base/Dockerfile.model
+++ b/base/Dockerfile.model
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5-apache/Dockerfile
+++ b/base/images/5-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5-fpm/Dockerfile
+++ b/base/images/5-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5.5-apache/Dockerfile
+++ b/base/images/5.5-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5.5-fpm/Dockerfile
+++ b/base/images/5.5-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5.6-apache/Dockerfile
+++ b/base/images/5.6-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/5.6-fpm/Dockerfile
+++ b/base/images/5.6-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7-apache/Dockerfile
+++ b/base/images/7-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7-fpm/Dockerfile
+++ b/base/images/7-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.0-apache/Dockerfile
+++ b/base/images/7.0-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.0-fpm/Dockerfile
+++ b/base/images/7.0-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \

--- a/base/images/fpm/Dockerfile
+++ b/base/images/fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
 		libfreetype6-dev \
 		libxml2-dev \
 		libicu-dev \
+		libzip-dev \
 		mysql-client \
 		wget \
 		unzip \


### PR DESCRIPTION
Fixes the following issue on Docker Hub build, tag `7-apache`:

```
Building in Docker Cloud's infrastructure...
Cloning into '.'...
KernelVersion: 4.4.0-1060-aws
Components: [{u'Version': u'18.03.1-ee-3', u'Name': u'Engine', u'Details': {u'KernelVersion': u'4.4.0-1060-aws', u'Os': u'linux', u'BuildTime': u'2018-08-30T18:42:30.000000000+00:00', u'ApiVersion': u'1.37', u'MinAPIVersion': u'1.12', u'GitCommit': u'b9a5c95', u'Arch': u'amd64', u'Experimental': u'false', u'GoVersion': u'go1.10.2'}}]
Arch: amd64
BuildTime: 2018-08-30T18:42:30.000000000+00:00
ApiVersion: 1.37
Platform: {u'Name': u''}
Version: 18.03.1-ee-3
MinAPIVersion: 1.12
GitCommit: b9a5c95
Os: linux
GoVersion: go1.10.2
Starting build of index.docker.io/prestashop/base:7-apache...
Step 1/12 : FROM php:7-apache
---> 2008844e89b9
Step 2/12 : LABEL maintainer="Thomas Nabord <thomas.nabord@prestashop.com>"
---> Running in a6bfee7afbbd
Removing intermediate container a6bfee7afbbd
---> 0ddfe6da7d99
Step 3/12 : ENV PS_DOMAIN="<to be defined>" DB_SERVER="<to be defined>" DB_PORT=3306 DB_NAME=prestashop DB_USER=root DB_PASSWD=admin DB_PREFIX=ps_ ADMIN_MAIL=demo@prestashop.com ADMIN_PASSWD=prestashop_demo PS_LANGUAGE=en PS_COUNTRY=GB PS_INSTALL_AUTO=0 PS_ERASE_DB=0 PS_DEV_MODE=0 PS_HOST_MODE=0 PS_DEMO_MODE=0 PS_HANDLE_DYNAMIC_DOMAIN=0 PS_FOLDER_ADMIN=admin PS_FOLDER_INSTALL=install
---> Running in e8fb444fed68
Removing intermediate container e8fb444fed68
---> e52aac6f66cd
Step 4/12 : RUN apt-get update && apt-get install -y libmcrypt-dev libjpeg62-turbo-dev libpcre3-dev libpng-dev libfreetype6-dev libxml2-dev libicu-dev mysql-client wget unzip && rm -rf /var/lib/apt/lists/* && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
---> Running in 44baa2e52da7
Get:1 http://security-cdn.debian.org/debian-security stretch/updates InRelease [94.3 kB]
Get:2 http://security-cdn.debian.org/debian-security buster/updates InRelease [38.3 kB]
Ign:3 http://cdn-fastly.deb.debian.org/debian stretch InRelease
Get:4 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:6 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 Packages [464 kB]
Get:5 http://cdn-fastly.deb.debian.org/debian buster InRelease [154 kB]
Get:7 http://cdn-fastly.deb.debian.org/debian buster-updates InRelease [47.6 kB]
Get:8 http://cdn-fastly.deb.debian.org/debian stretch Release [118 kB]
Get:9 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg [2434 B]
Get:10 http://cdn-fastly.deb.debian.org/debian stretch-updates/main amd64 Packages [5152 B]
Get:11 http://cdn-fastly.deb.debian.org/debian buster/main amd64 Packages [7819 kB]
Get:12 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 Packages [7089 kB]
Fetched 15.9 MB in 13s (1214 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
default-mysql-client icu-devtools libaio1 libconfig-inifiles-perl
libdbd-mysql-perl libdbi-perl libfreetype6 libjemalloc1 libjpeg62-turbo
libmariadbclient18 libmcrypt4 libpcre16-3 libpcre32-3 libpcrecpp0v5
libpng-tools libpng16-16 libreadline5 libterm-readkey-perl
mariadb-client-10.1 mariadb-client-core-10.1 mariadb-common mysql-common
readline-common zlib1g-dev
Suggested packages:
libclone-perl libmldbm-perl libnet-daemon-perl libsql-statement-perl icu-doc
mcrypt readline-doc zip
The following NEW packages will be installed:
default-mysql-client icu-devtools libaio1 libconfig-inifiles-perl
libdbd-mysql-perl libdbi-perl libfreetype6 libfreetype6-dev libicu-dev
libjemalloc1 libjpeg62-turbo libjpeg62-turbo-dev libmariadbclient18
libmcrypt-dev libmcrypt4 libpcre16-3 libpcre3-dev libpcre32-3 libpcrecpp0v5
libpng-dev libpng-tools libpng16-16 libreadline5 libterm-readkey-perl
libxml2-dev mariadb-client-10.1 mariadb-client-core-10.1 mariadb-common
mysql-client mysql-common readline-common unzip wget zlib1g-dev
0 upgraded, 34 newly installed, 0 to remove and 6 not upgraded.
Need to get 40.5 MB of archives.
After this operation, 197 MB of additional disk space will be used.
Get:1 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 mariadb-common all 10.1.37-0+deb9u1 [28.0 kB]
Get:2 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 mariadb-client-core-10.1 amd64 10.1.37-0+deb9u1 [5125 kB]
Get:5 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpcrecpp0v5 amd64 2:8.39-3 [151 kB]
Get:6 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 readline-common all 7.0-3 [70.4 kB]
Get:7 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 wget amd64 1.18-5+deb9u2 [799 kB]
Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 mysql-common all 5.8+1.0.2 [5608 B]
Get:9 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libaio1 amd64 0.3.110-3 [9412 B]
Get:10 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libreadline5 amd64 5.2+dfsg-3+b1 [119 kB]
Get:11 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libconfig-inifiles-perl all 2.94-1 [53.4 kB]
Get:12 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjemalloc1 amd64 3.6.0-9.1 [89.8 kB]
Get:13 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 default-mysql-client all 1.0.2 [3050 B]
Get:14 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 icu-devtools amd64 57.1-6+deb9u2 [178 kB]
Get:15 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libdbi-perl amd64 1.636-1+b1 [766 kB]
Get:16 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libdbd-mysql-perl amd64 4.041-2 [114 kB]
Get:17 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng16-16 amd64 1.6.28-1 [280 kB]
Get:18 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libfreetype6 amd64 2.6.3-3.2 [438 kB]
Get:19 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 zlib1g-dev amd64 1:1.2.8.dfsg-5 [205 kB]
Get:20 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng-dev amd64 1.6.28-1 [250 kB]
Get:21 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libfreetype6-dev amd64 2.6.3-3.2 [5815 kB]
Get:3 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 mariadb-client-10.1 amd64 10.1.37-0+deb9u1 [5910 kB]
Get:22 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libicu-dev amd64 57.1-6+deb9u2 [16.5 MB]
Get:4 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 libmariadbclient18 amd64 10.1.37-0+deb9u1 [783 kB]
Get:23 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjpeg62-turbo amd64 1:1.5.1-2 [134 kB]
Get:24 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjpeg62-turbo-dev amd64 1:1.5.1-2 [210 kB]
Get:25 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libmcrypt4 amd64 2.5.8-3.3 [71.2 kB]
Get:26 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libmcrypt-dev amd64 2.5.8-3.3 [92.9 kB]
Get:27 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpcre16-3 amd64 2:8.39-3 [258 kB]
Get:28 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpcre32-3 amd64 2:8.39-3 [248 kB]
Get:29 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpcre3-dev amd64 2:8.39-3 [647 kB]
Get:30 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng-tools amd64 1.6.28-1 [133 kB]
Get:31 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libterm-readkey-perl amd64 2.37-1 [27.2 kB]
Get:32 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libxml2-dev amd64 2.9.4+dfsg1-2.2+deb9u2 [812 kB]
Get:33 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 mysql-client amd64 5.5.9999+default [1698 B]
Get:34 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 unzip amd64 6.0-21 [170 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 40.5 MB in 2s (14.4 MB/s)
Selecting previously unselected package libpcrecpp0v5:amd64.
(Reading database ... (Reading database ... 5% (Reading database ... 10% (Reading database ... 15% (Reading database ... 20% (Reading database ... 25% (Reading database ... 30% (Reading database ... 35% (Reading database ... 40% (Reading database ... 45% (Reading database ... 50% (Reading database ... 55% (Reading database ... 60% (Reading database ... 65% (Reading database ... 70% (Reading database ... 75% (Reading database ... 80%
(Reading database ... 85% (Reading database ... 90% (Reading database ... 95%
(Reading database ... 100% (Reading database ... 13064 files and directories currently installed.)
Preparing to unpack .../00-libpcrecpp0v5_2%3a8.39-3_amd64.deb ...
Unpacking libpcrecpp0v5:amd64 (2:8.39-3) ...
Selecting previously unselected package readline-common.
Preparing to unpack .../01-readline-common_7.0-3_all.deb ...
Unpacking readline-common (7.0-3) ...
Selecting previously unselected package wget.
Preparing to unpack .../02-wget_1.18-5+deb9u2_amd64.deb ...
Unpacking wget (1.18-5+deb9u2) ...
Selecting previously unselected package mysql-common.
Preparing to unpack .../03-mysql-common_5.8+1.0.2_all.deb ...
Unpacking mysql-common (5.8+1.0.2) ...
Selecting previously unselected package mariadb-common.
Preparing to unpack .../04-mariadb-common_10.1.37-0+deb9u1_all.deb ...
Unpacking mariadb-common (10.1.37-0+deb9u1) ...
Selecting previously unselected package libaio1:amd64.
Preparing to unpack .../05-libaio1_0.3.110-3_amd64.deb ...
Unpacking libaio1:amd64 (0.3.110-3) ...
Selecting previously unselected package libreadline5:amd64.
Preparing to unpack .../06-libreadline5_5.2+dfsg-3+b1_amd64.deb ...
Unpacking libreadline5:amd64 (5.2+dfsg-3+b1) ...
Selecting previously unselected package mariadb-client-core-10.1.
Preparing to unpack .../07-mariadb-client-core-10.1_10.1.37-0+deb9u1_amd64.deb ...
Unpacking mariadb-client-core-10.1 (10.1.37-0+deb9u1) ...
Selecting previously unselected package libconfig-inifiles-perl.
Preparing to unpack .../08-libconfig-inifiles-perl_2.94-1_all.deb ...
Unpacking libconfig-inifiles-perl (2.94-1) ...
Selecting previously unselected package libjemalloc1.
Preparing to unpack .../09-libjemalloc1_3.6.0-9.1_amd64.deb ...
Unpacking libjemalloc1 (3.6.0-9.1) ...
Selecting previously unselected package mariadb-client-10.1.
Preparing to unpack .../10-mariadb-client-10.1_10.1.37-0+deb9u1_amd64.deb ...
Unpacking mariadb-client-10.1 (10.1.37-0+deb9u1) ...
Selecting previously unselected package default-mysql-client.
Preparing to unpack .../11-default-mysql-client_1.0.2_all.deb ...
Unpacking default-mysql-client (1.0.2) ...
Selecting previously unselected package icu-devtools.
Preparing to unpack .../12-icu-devtools_57.1-6+deb9u2_amd64.deb ...
Unpacking icu-devtools (57.1-6+deb9u2) ...
Selecting previously unselected package libdbi-perl.
Preparing to unpack .../13-libdbi-perl_1.636-1+b1_amd64.deb ...
Unpacking libdbi-perl (1.636-1+b1) ...
Selecting previously unselected package libmariadbclient18:amd64.
Preparing to unpack .../14-libmariadbclient18_10.1.37-0+deb9u1_amd64.deb ...
Unpacking libmariadbclient18:amd64 (10.1.37-0+deb9u1) ...
Selecting previously unselected package libdbd-mysql-perl.
Preparing to unpack .../15-libdbd-mysql-perl_4.041-2_amd64.deb ...
Unpacking libdbd-mysql-perl (4.041-2) ...
Selecting previously unselected package libpng16-16:amd64.
Preparing to unpack .../16-libpng16-16_1.6.28-1_amd64.deb ...
Unpacking libpng16-16:amd64 (1.6.28-1) ...
Selecting previously unselected package libfreetype6:amd64.
Preparing to unpack .../17-libfreetype6_2.6.3-3.2_amd64.deb ...
Unpacking libfreetype6:amd64 (2.6.3-3.2) ...
Selecting previously unselected package zlib1g-dev:amd64.
Preparing to unpack .../18-zlib1g-dev_1%3a1.2.8.dfsg-5_amd64.deb ...
Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-5) ...
Selecting previously unselected package libpng-dev:amd64.
Preparing to unpack .../19-libpng-dev_1.6.28-1_amd64.deb ...
Unpacking libpng-dev:amd64 (1.6.28-1) ...
Selecting previously unselected package libfreetype6-dev.
Preparing to unpack .../20-libfreetype6-dev_2.6.3-3.2_amd64.deb ...
Unpacking libfreetype6-dev (2.6.3-3.2) ...
Selecting previously unselected package libicu-dev.
Preparing to unpack .../21-libicu-dev_57.1-6+deb9u2_amd64.deb ...
Unpacking libicu-dev (57.1-6+deb9u2) ...
Selecting previously unselected package libjpeg62-turbo:amd64.
Preparing to unpack .../22-libjpeg62-turbo_1%3a1.5.1-2_amd64.deb ...
Unpacking libjpeg62-turbo:amd64 (1:1.5.1-2) ...
Selecting previously unselected package libjpeg62-turbo-dev:amd64.
Preparing to unpack .../23-libjpeg62-turbo-dev_1%3a1.5.1-2_amd64.deb ...
Unpacking libjpeg62-turbo-dev:amd64 (1:1.5.1-2) ...
Selecting previously unselected package libmcrypt4.
Preparing to unpack .../24-libmcrypt4_2.5.8-3.3_amd64.deb ...
Unpacking libmcrypt4 (2.5.8-3.3) ...
Selecting previously unselected package libmcrypt-dev.
Preparing to unpack .../25-libmcrypt-dev_2.5.8-3.3_amd64.deb ...
Unpacking libmcrypt-dev (2.5.8-3.3) ...
Selecting previously unselected package libpcre16-3:amd64.
Preparing to unpack .../26-libpcre16-3_2%3a8.39-3_amd64.deb ...
Unpacking libpcre16-3:amd64 (2:8.39-3) ...
Selecting previously unselected package libpcre32-3:amd64.
Preparing to unpack .../27-libpcre32-3_2%3a8.39-3_amd64.deb ...
Unpacking libpcre32-3:amd64 (2:8.39-3) ...
Selecting previously unselected package libpcre3-dev:amd64.
Preparing to unpack .../28-libpcre3-dev_2%3a8.39-3_amd64.deb ...
Unpacking libpcre3-dev:amd64 (2:8.39-3) ...
Selecting previously unselected package libpng-tools.
Preparing to unpack .../29-libpng-tools_1.6.28-1_amd64.deb ...
Unpacking libpng-tools (1.6.28-1) ...
Selecting previously unselected package libterm-readkey-perl.
Preparing to unpack .../30-libterm-readkey-perl_2.37-1_amd64.deb ...
Unpacking libterm-readkey-perl (2.37-1) ...
Selecting previously unselected package libxml2-dev:amd64.
Preparing to unpack .../31-libxml2-dev_2.9.4+dfsg1-2.2+deb9u2_amd64.deb ...
Unpacking libxml2-dev:amd64 (2.9.4+dfsg1-2.2+deb9u2) ...
Selecting previously unselected package mysql-client.
Preparing to unpack .../32-mysql-client_5.5.9999+default_amd64.deb ...
Unpacking mysql-client (5.5.9999+default) ...
Selecting previously unselected package unzip.
Preparing to unpack .../33-unzip_6.0-21_amd64.deb ...
Unpacking unzip (6.0-21) ...
Setting up readline-common (7.0-3) ...
Setting up libconfig-inifiles-perl (2.94-1) ...
Setting up libjpeg62-turbo:amd64 (1:1.5.1-2) ...
Processing triggers for mime-support (3.60) ...
Setting up libjemalloc1 (3.6.0-9.1) ...
Setting up libpng16-16:amd64 (1.6.28-1) ...
Setting up libpng-tools (1.6.28-1) ...
Setting up mysql-common (5.8+1.0.2) ...
update-alternatives: using /etc/mysql/my.cnf.fallback to provide /etc/mysql/my.cnf (my.cnf) in auto mode
Setting up unzip (6.0-21) ...
Setting up libmariadbclient18:amd64 (10.1.37-0+deb9u1) ...
Setting up libterm-readkey-perl (2.37-1) ...
Setting up libfreetype6:amd64 (2.6.3-3.2) ...
Processing triggers for libc-bin (2.24-11+deb9u3) ...
Setting up libaio1:amd64 (0.3.110-3) ...
Setting up wget (1.18-5+deb9u2) ...
Setting up libpcrecpp0v5:amd64 (2:8.39-3) ...
Setting up libpcre32-3:amd64 (2:8.39-3) ...
Setting up icu-devtools (57.1-6+deb9u2) ...
Setting up libpcre16-3:amd64 (2:8.39-3) ...
Setting up libjpeg62-turbo-dev:amd64 (1:1.5.1-2) ...
Setting up libreadline5:amd64 (5.2+dfsg-3+b1) ...
Setting up libmcrypt4 (2.5.8-3.3) ...
Setting up libdbi-perl (1.636-1+b1) ...
Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-5) ...
Setting up mariadb-common (10.1.37-0+deb9u1) ...
update-alternatives: using /etc/mysql/mariadb.cnf to provide /etc/mysql/my.cnf (my.cnf) in auto mode
Setting up libpcre3-dev:amd64 (2:8.39-3) ...
Setting up mariadb-client-core-10.1 (10.1.37-0+deb9u1) ...
Setting up libicu-dev (57.1-6+deb9u2) ...
Setting up libxml2-dev:amd64 (2.9.4+dfsg1-2.2+deb9u2) ...
Setting up libmcrypt-dev (2.5.8-3.3) ...
Setting up libpng-dev:amd64 (1.6.28-1) ...
Setting up libdbd-mysql-perl (4.041-2) ...
Setting up mariadb-client-10.1 (10.1.37-0+deb9u1) ...
Setting up libfreetype6-dev (2.6.3-3.2) ...
Setting up default-mysql-client (1.0.2) ...
Setting up mysql-client (5.5.9999+default) ...

[...]
/usr/local/include/php
checking if debug is enabled...
no
checking if zts is enabled...
no
checking for re2c... re2c
checking for re2c version...
0.16 (ok)
checking for gawk... no
checking for nawk...
nawk
checking if nawk is broken...
no
checking for zip archive read/writesupport...
yes, shared
checking for the location of libz...
no
checking pcre install prefix...
no
checking libzip...
yes
checking for the location of zlib...
/usr
checking for pkg-config...
/usr/bin/pkg-config
checking for libzip...
not found
configure: error: Please reinstall the libzip distribution
```