### PR TITLE
Allow all languages to be installed with PrestaShop 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ However, if you want to customize the container execution, here are many availab
 * **PS_DOMAIN**: When installing automatically your shop, you can tell the shop how it will be reached. For advanced users only *(no default value)*
 * **PS_LANGUAGE**: Change the default language installed with PrestaShop *(default value: en)*
 * **PS_COUNTRY**: Change the default country installed with PrestaShop *(default value: GB)*
+* **PS_ALL_LANGUAGES**: Install all the existing languages for the current version. *(default value: 0)*
 * **PS_FOLDER_ADMIN**: Change the name of the `admin` folder *(default value: admin. But will be automatically changed later)*
 * **PS_FOLDER_INSTALL**: Change the name of the `install` folder *(default value: install. But must be changed anyway later)*
 

--- a/base/Dockerfile.model
+++ b/base/Dockerfile.model
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5-apache/Dockerfile
+++ b/base/images/5-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5-fpm/Dockerfile
+++ b/base/images/5-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5.5-apache/Dockerfile
+++ b/base/images/5.5-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5.5-apache/config_files/docker_run.sh
+++ b/base/images/5.5-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5.5-fpm/Dockerfile
+++ b/base/images/5.5-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5.5-fpm/config_files/docker_run.sh
+++ b/base/images/5.5-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5.6-apache/Dockerfile
+++ b/base/images/5.6-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/5.6-fpm/Dockerfile
+++ b/base/images/5.6-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7-apache/Dockerfile
+++ b/base/images/7-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7-fpm/Dockerfile
+++ b/base/images/7-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.0-apache/Dockerfile
+++ b/base/images/7.0-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.0-fpm/Dockerfile
+++ b/base/images/7.0-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/apache/Dockerfile
+++ b/base/images/apache/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'

--- a/base/images/fpm/Dockerfile
+++ b/base/images/fpm/Dockerfile
@@ -12,6 +12,7 @@ ADMIN_MAIL=demo@prestashop.com \
 ADMIN_PASSWD=prestashop_demo \
 PS_LANGUAGE=en \
 PS_COUNTRY=GB \
+PS_ALL_LANGUAGES=0 \
 PS_INSTALL_AUTO=0 \
 PS_ERASE_DB=0 \
 PS_DEV_MODE=0 \

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -60,7 +60,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
 			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
 			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--newsletter=0 --send_email=0
+			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'


### PR DESCRIPTION
Introduce a new environment variable: `PS_ALL_LANGUAGES`: 1/0

Will install all existing languages with PrestaShop if `PS_INSTALL_AUTO`=1.

![capture d ecran de 2019-01-04 11-55-37](https://user-images.githubusercontent.com/6768917/50687526-e563d100-1021-11e9-9684-d5fdbe64cb3d.png)
