### PR TITLE
Install scripts

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -59,12 +59,12 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			if [ $DB_PASSWD = "" ]; then
                         	echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
-				echo "\n* Creating database $DN_NAME..."
+				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
 				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
-				echo "\n* Creating database $DN_NAME..."
+				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi

--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -15,15 +15,15 @@ if [ ! -f ./config/settings.inc.php  ]; then
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
 
-        if [ -d /tmp/pre-install-scripts/ ]; then
-                echo "\n* Running pre-install script(s)..."
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
 
-                for i in `ls /tmp/pre-install-scripts/`;do
-                        /tmp/pre-install-scripts/$i
-                done
-        else
-                echo "\n* No pre-install script found, let's continue..."
-        fi
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -43,28 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-                    echo "\n* Checking if $DB_SERVER is available..."
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                                echo "\n* Dropping existing database $DB_NAME..."
-                                mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
-                                echo "\n* Creating database $DN_NAME..."
-                                mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
-                        else
-                                echo "\n* Dropping existing database $DB_NAME..."
-                                mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
-                                echo "\n* Creating database $DN_NAME..."
-                                mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DN_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
+			else
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DN_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -72,30 +73,30 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
-                echo "\n* Launching the installer script..."
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
 
-        if [ -d /tmp/post-install-scripts/ ]; then
-                echo "\n* Running post-install script(s)..."
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
 
-                for i in `ls /tmp/post-install-scripts/`;do
-                        /tmp/post-install-scripts/$i
-                done
-        else
-                echo "\n* No post-install script found, let's continue..."
-        fi
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
 
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
@@ -106,7 +107,7 @@ if [ -d /tmp/init-scripts/ ]; then
 		/tmp/init-scripts/$i
 	done
 else
-        echo "\n* No init script found, let's continue..."
+	echo "\n* No init script found, let's continue..."
 fi
 
 exec {PHP_CMD}

--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -44,11 +44,15 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
-			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+                                echo "\n* Dropping existing database $DB_NAME..."
+                                mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+                                echo "\n* Creating database $DN_NAME..."gg
+                                mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
+                        else
+                                echo "\n* Dropping existing database $DB_NAME..."
+                                mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+                                echo "\n* Creating database $DN_NAME..."
+                                mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec apache2-foreground

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
@@ -13,6 +14,16 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	cp -n -R -p /tmp/data-ps/prestashop/* /var/www/html
 
 	cp -n -p /tmp/defines_custom.inc.php /var/www/html/config/defines_custom.inc.php
+
+	if [ -d /tmp/pre-install-scripts/ ]; then
+		echo "\n* Running pre-install script(s)..."
+
+		for i in `ls /tmp/pre-install-scripts/`;do
+			/tmp/pre-install-scripts/$i
+		done
+	else
+		echo "\n* No pre-install script found, let's continue..."
+	fi
 
 	if [ $PS_FOLDER_INSTALL != "install" ]; then
 		echo "\n* Renaming install folder as $PS_FOLDER_INSTALL ...";
@@ -32,23 +43,29 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	if [ $PS_INSTALL_AUTO = 1 ]; then
 		RET=1
 		while [ $RET -ne 0 ]; do
-		    mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-		    RET=$?
-		    if [ $RET -ne 0 ]; then
-		        echo "\n* Waiting for confirmation of MySQL service startup";
-		        sleep 5
-		    fi
+			echo "\n* Checking if $DB_SERVER is available..."
+			mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+			RET=$?
+
+			if [ $RET -ne 0 ]; then
+		        	echo "\n* Waiting for confirmation of MySQL service startup";
+				sleep 5
+			fi
 		done
 
 		echo "\n* Installing PrestaShop, this may take a while ...";
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME --force 2> /dev/null;
+                        	echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
 			else
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD drop $DB_NAME --force 2> /dev/null;
-				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force 2> /dev/null;
+				echo "\n* Dropping existing database $DB_NAME..."
+				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
+				echo "\n* Creating database $DB_NAME..."
+				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force;
 			fi
 		fi
 
@@ -56,19 +73,41 @@ if [ ! -f ./config/settings.inc.php  ]; then
 			export PS_DOMAIN=$(hostname -i)
 		fi
 
+		echo "\n* Launching the installer script..."
 		runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
-		  --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-			--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-			--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
-			--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
+		--domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
+		--db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
+		--password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+		--all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
 		if [ $? -ne 0 ]; then
 			echo 'warning: PrestaShop installation failed.'
 		fi
 	fi
+
+	if [ -d /tmp/post-install-scripts/ ]; then
+		echo "\n* Running post-install script(s)..."
+
+		for i in `ls /tmp/post-install-scripts/`;do
+			/tmp/post-install-scripts/$i
+		done
+	else
+		echo "\n* No post-install script found, let's continue..."
+	fi
+
 else
-    echo "\n* Pretashop Core already installed...";
+	echo "\n* Pretashop Core already installed...";
 fi
 
 echo "\n* Almost ! Starting web server now\n";
+
+if [ -d /tmp/init-scripts/ ]; then
+	echo "\n* Running init script(s)..."
+	for i in `ls /tmp/init-scripts/`;do
+		/tmp/init-scripts/$i
+	done
+else
+	echo "\n* No init script found, let's continue..."
+fi
+
 exec php-fpm


### PR DESCRIPTION
- Additional scripts can now be run:
   => At pre-install (after files copy)
   => At post-install (after PS setup)
   => At init (just before webserver launch)
  At each step, will check if scripts are available and will run them
- Adding some more logs during script run
-  Script will crash if any step fails 
- Replace mysqladmin drop DB with mysql drop if exists DB