### PR TITLE
Adding multi install lock

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+        echo "\n* Setting up install lock file..."
+        touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -94,6 +98,20 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+        rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+        echo "\n* Another setup is currently running..."
+        sleep 10
+        exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+        echo "\n* Shop seems setup but remaining install lock still present..." 
+        sleep 10
+        exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -9,8 +9,8 @@ fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
 
-        echo "\n* Setting up install lock file..."
-        touch ./install.lock
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
 
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
@@ -61,7 +61,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -99,19 +99,20 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
 		echo "\n* No post-install script found, let's continue..."
 	fi
 
-        rm ./install.lock
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
 
 elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
 
-        echo "\n* Another setup is currently running..."
-        sleep 10
-        exit 42
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
 
 elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
 
-        echo "\n* Shop seems setup but remaining install lock still present..." 
-        sleep 10
-        exit 42
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/5-apache/Dockerfile
+++ b/base/images/5-apache/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 		libxml2-dev \
 		libicu-dev \
 		libzip-dev \
-		mysql-client \
+		default-mysql-client \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/5-fpm/Dockerfile
+++ b/base/images/5-fpm/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 		libxml2-dev \
 		libicu-dev \
 		libzip-dev \
-		mysql-client \
+		default-mysql-client \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/5.6-apache/Dockerfile
+++ b/base/images/5.6-apache/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 		libxml2-dev \
 		libicu-dev \
 		libzip-dev \
-		mysql-client \
+		default-mysql-client \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/5.6-fpm/Dockerfile
+++ b/base/images/5.6-fpm/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 		libxml2-dev \
 		libicu-dev \
 		libzip-dev \
-		mysql-client \
+		default-mysql-client \
 		wget \
 		unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -7,7 +7,11 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
 	exit 1
 fi
 
-if [ ! -f ./config/settings.inc.php  ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+
+	echo "\n* Setting up install lock file..."
+	touch ./install.lock
+
 	echo "\n* Reapplying PrestaShop files for enabled volumes ...";
 
 	# init if empty
@@ -57,7 +61,7 @@ if [ ! -f ./config/settings.inc.php  ]; then
 		if [ $PS_ERASE_DB = 1 ]; then
 			echo "\n* Drop & recreate mysql database...";
 			if [ $DB_PASSWD = "" ]; then
-                        	echo "\n* Dropping existing database $DB_NAME..."
+				echo "\n* Dropping existing database $DB_NAME..."
 				mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "drop database if exists $DB_NAME;"
 				echo "\n* Creating database $DB_NAME..."
 				mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER create $DB_NAME -p$DB_PASSWD --force;
@@ -94,6 +98,21 @@ if [ ! -f ./config/settings.inc.php  ]; then
 	else
 		echo "\n* No post-install script found, let's continue..."
 	fi
+
+	echo "\n* Setup completed, removing lock file..."
+	rm ./install.lock
+
+elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Another setup is currently running..."
+	sleep 10
+	exit 42
+
+elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+
+	echo "\n* Shop seems setup but remaining install lock still present..."
+	sleep 10
+	exit 42
 
 else
 	echo "\n* Pretashop Core already installed...";


### PR DESCRIPTION
In our current setup, we are using several containers to run the prestashop application, pointing to NFS mount points.
Hence, at startup, the containers are launching the setup, unaware that the others are already launching the setup... Which is a very dirty situation.
So, in order for manage this situation, we are setting up an install.lock file, for the other containers to be aware of an installation taking place and waiting for it to finish before resuming their normal operations.