### PR TITLE
Add db check

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -5,6 +5,19 @@ if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '
     echo >&2 '  You need to specify DB_SERVER in order to proceed'
     exit 1
+elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
+    RET=1
+    while [ $RET -ne 0 ]; do
+        echo "\n* Checking if $DB_SERVER is available..."
+        mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            echo "\n* Waiting for confirmation of MySQL service startup";
+            sleep 5
+        fi
+    done
+        echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
 if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -62,19 +62,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     fi
 
     if [ $PS_INSTALL_AUTO = 1 ]; then
-        RET=1
-        while [ $RET -ne 0 ]; do
-            echo "\n* Checking if $DB_SERVER is available..."
-            mysql -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD -e "status" > /dev/null 2>&1
-            RET=$?
-
-            if [ $RET -ne 0 ]; then
-                    echo "\n* Waiting for confirmation of MySQL service startup";
-                sleep 5
-            fi
-        done
 
         echo "\n* Installing PrestaShop, this may take a while ...";
+
         if [ $PS_ERASE_DB = 1 ]; then
             echo "\n* Drop & recreate mysql database...";
             if [ $DB_PASSWD = "" ]; then


### PR DESCRIPTION
Adding a DB check at the start of entrypoint script if PS_INSTALL_AUTO=1 is configured.
There is no reason to reapply files or perform any other operation if DB is not available, it won't work in the end.
This way, container will restart until DB is available, avoiding non idempotent operations to run.