### PR TITLE
No memory limit on install

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/5-apache/config_files/docker_run.sh
+++ b/base/images/5-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/5-fpm/config_files/docker_run.sh
+++ b/base/images/5-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/5.6-apache/config_files/docker_run.sh
+++ b/base/images/5.6-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/5.6-fpm/config_files/docker_run.sh
+++ b/base/images/5.6-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7-apache/config_files/docker_run.sh
+++ b/base/images/7-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7-fpm/config_files/docker_run.sh
+++ b/base/images/7-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.0-apache/config_files/docker_run.sh
+++ b/base/images/7.0-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.0-fpm/config_files/docker_run.sh
+++ b/base/images/7.0-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/apache/config_files/docker_run.sh
+++ b/base/images/apache/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \

--- a/base/images/fpm/config_files/docker_run.sh
+++ b/base/images/fpm/config_files/docker_run.sh
@@ -87,7 +87,7 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
         fi
 
         echo "\n* Launching the installer script..."
-        runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
+        runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
         --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \


### PR DESCRIPTION
When installing PS with all the languages (for instance on https://github.com/PrestaShop/docker-internal-images/), it appeared in the logs that we use too much memory to complete the installation.

To allow the docker images to be built properly, we temporarily apply a `memory_limit=-1` for the installation script.

```
* Launching the installer script...
[91mPHP Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 106496 bytes) in /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Translation/Loader/XliffFileLoader.php on line 253
[0m
[91mPHP Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 69632 bytes) in /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Filesystem/Filesystem.php on line 165
[0m
Removing intermediate container e5bbea367397
The command '/bin/sh -c service mysql start && /tmp/docker_run.sh' returned a non-zero code: 255
```