### PR TITLE
Delete install directory on successful (auto) installation

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -91,6 +91,9 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
 
         if [ $? -ne 0 ]; then
             echo 'warning: PrestaShop installation failed.'
+        else
+            echo "\n* Removing install folder..."
+            rm -r /var/www/html/$PS_FOLDER_INSTALL/
         fi
     fi
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description? | Deletes the `install` directory when automatic installation was successful.
| Type         | improvement
| BC breaks    | no
| Deprecations | no
| Fixed ticket | Fixes #204.
| How to test  | See detailed info below.

**Scenarios to test:**
Start Docker container with env var `PS_INSTALL_AUTO=1` and:
* Proper DB params (successful installation): `install/` directory must be deleted.
* Invalid DB config (installation error): `install/` directory must NOT be deleted.

Additionally, verify it supports custom install directory (use `PS_FOLDER_INSTALL` env var).