### PR TITLE
Replace outdated Travis badge by GA badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PrestaShop on Docker
 
-[![Build Status](https://travis-ci.org/PrestaShop/docker.svg?branch=master)](https://travis-ci.org/PrestaShop/docker)
+![Tests](https://github.com/PrestaShop/docker/workflows/Run%20tests/badge.svg)
+![Codestyle](https://github.com/PrestaShop/docker/workflows/Run%20Flake8/badge.svg)
 
 ## Supported tags
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Following @PierreRambaud refactoring, CI is now being managed by GitHub Action and not Travis. So I replace outdated Travis badge by GA badges
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
