### PR TITLE
update php.ini

### DIFF
--- a/base/config_files/php.ini
+++ b/base/config_files/php.ini
@@ -390,7 +390,7 @@ max_input_vars = 20000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 1024M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
Avoid Error 500 `PHP Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 262144 bytes)`

With all templates.

