### PR TITLE
Add bcmath php extension

### DIFF
--- a/base/Dockerfile.model
+++ b/base/Dockerfile.model
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.3-apache/Dockerfile
+++ b/base/images/7.3-apache/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.3-fpm/Dockerfile
+++ b/base/images/7.3-fpm/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.4-apache/Dockerfile
+++ b/base/images/7.4-apache/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/7.4-fpm/Dockerfile
+++ b/base/images/7.4-fpm/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/8.0-apache/Dockerfile
+++ b/base/images/8.0-apache/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \

--- a/base/images/8.0-fpm/Dockerfile
+++ b/base/images/8.0-fpm/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
-RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip
+RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \
     && if [ -d "/usr/src/php/ext/mysql" ]; then docker-php-ext-install mysql; fi \


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The bcmath extension is used and unit tests fail if it is not installed, why not include it?
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Image builds and runs Prestashop as expected
| Possible impacts? | I think no


When I do:
```
docker compose up -d
docker compose exec prestashop-git ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml
```
I get:
```
1) Tests\Unit\Adapter\Tax\TaxComputerTest::testComputePriceWithoutTaxes with data set #5 (16.43, '8.333333333', '7.157376000000', 12)
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'7.157376000000'
+'7.157376391000'

```
with this patch I think it would no longer be a issue.