### PR TITLE
Update version manager to handle PS 8.0.0 versions

### DIFF
--- a/prestashop_docker/version_manager.py
+++ b/prestashop_docker/version_manager.py
@@ -177,15 +177,20 @@ class VersionManager:
         aliases = {}
         previous_version = {}
         for ps_version in VERSIONS.keys():
-            if len(ps_version.split('.')) < 4:
+            full_splitted_version = ps_version.split('.')
+            if len(full_splitted_version) < 3 or int(full_splitted_version[0]) < 8 and len(full_splitted_version) < 4:
                 aliases[ps_version] = {
                     'value': ps_version
                 }
                 continue
 
-            # PrestaShop versions are in format 1.MAJOR.MINOR.PATCH
+            # PrestaShop versions before 8 are in format 1.MAJOR.MINOR.PATCH
+            # Starting version 8, format is MAJOR.MINOR.PATCH
             splitted_version = ps_version.split('.', 1)
-            current_version = semver.VersionInfo.parse(splitted_version[1])
+            if int(splitted_version[0]) >= 8:
+                current_version = semver.VersionInfo.parse(ps_version)
+            else:
+                current_version = semver.VersionInfo.parse(splitted_version[1])
             # Ignore prerelease versions
             if current_version.prerelease:
                 aliases[ps_version] = {
@@ -193,14 +198,20 @@ class VersionManager:
                 }
                 continue
 
-            version_name = splitted_version[0] + '.' + str(current_version.major)
+            if int(splitted_version[0]) >= 8:
+                version_name = str(current_version.major)
+            else:
+                version_name = splitted_version[0] + '.' + str(current_version.major)
             if version_name not in previous_version or aliases[version_name]['version'] < current_version:
                 aliases[version_name] = {
                     'version': current_version,
                     'value': ps_version
                 }
 
-            version_with_major_name = splitted_version[0] + '.' + str(current_version.major) + '.' + str(current_version.minor)
+            if int(splitted_version[0]) >= 8:
+                version_with_major_name = str(current_version.major) + '.' + str(current_version.minor)
+            else:
+                version_with_major_name = splitted_version[0] + '.' + str(current_version.major) + '.' + str(current_version.minor)
             if version_with_major_name not in aliases or aliases[version_with_major_name]['version'] < current_version:
                 aliases[version_with_major_name] = {
                     'version': current_version,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to fix an error that happens while trying to push PrestaShop >= 8 images (https://github.com/PrestaShop/docker/runs/7991352395?check_suite_focus=true#step:6:292) by handling correctly the new version format (without the leading `1`)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should pass
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
