### PR TITLE
Upgrade memory_limit from 256M to 512M

### DIFF
--- a/base/config_files/php.ini
+++ b/base/config_files/php.ini
@@ -390,7 +390,7 @@ max_input_vars = 20000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Upgrade memory_limit from 256M to 512M to avoid some "Error: Allowed memory size"
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| Sponsor company   | Fintecture
| How to test?      | Nothing should change

We think it's better for development purposes but maybe your prefer to follow this line from "[The more the merrier. We recommend setting the memory allocation per script (memory_limit) to a minimum of 256M.](https://devdocs.prestashop-project.org/8/basics/installation/system-requirements/)"?
