### PR TITLE
Force build and push of all tags in each publish actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish containers
 
-on: 
+on:
   push:
     branches:
       - master
@@ -83,4 +83,4 @@ jobs:
 
       - name: Push Docker images
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        run: ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }}
+        run: ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }} --force


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Force build and push of all tags in each publish actions, this way when we update the config files they are forcefully updated in docker hub even if they already exist This is critical for nightly build, and a nice to have for release builds if we want to be able to improve the dockers<br>However it also means we could push some invalid new builds so we'll have to remain ary of the dockers evolution in the future
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
