### PR TITLE
Fix configuration of gd in base images below PHP 7.4

### DIFF
--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \

--- a/base/images/7.3-apache/Dockerfile
+++ b/base/images/7.3-apache/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \

--- a/base/images/7.3-fpm/Dockerfile
+++ b/base/images/7.3-fpm/Dockerfile
@@ -40,7 +40,9 @@ RUN apt-get update \
         libonig-dev
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
+
+# PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 
 RUN docker-php-source extract \


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When running versions of PrestaShop with old base images, `imagecreatefromjpeg()` is undefined. This is caused by a change we applied on all images about GD, which actually only valid from PHP 7.4. Although it never failed, the gd extension was not loaded on previous versions.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Unblocks https://github.com/PrestaShop/autoupgrade/pull/688
| Sponsor company   | /
| How to test?      | Look below

## How to test

* Reach the folder `base/images/7.1-apache`
* Build the image with the command `docker build -t prestashop/base:test-7.1-apache .`
* Wait for the build to succeed
* Run the container with `docker run --rm -ti --entrypoint="php"  prestashop/base:test-7.1-apache`
* You will be able to write PHP code to check the `gd` library is properly loaded. Paste this code then quit with `ctrl`+`D` or `cmd`+`D`
```php
<?php

imagecreatefromjpeg();
```
* If you build from the master branch this error will be reported: `PHP Fatal error:  Uncaught Error: Call to undefined function imagecreatefromjpeg() in -:3`
* From this PR, you get another error because I didn't send any parameters, but at least the function now exists: `PHP Warning:  imagecreatefromjpeg() expects exactly 1 parameter, 0 given in - on line 3`


## Reported errors:

```prestashop_autoupgrade  | [Thu Apr 11 16:50:41.395837 2024] [php7:error] [pid 65] [client 192.168.0.1:42770] PHP Fatal error:  Uncaught Error: Call to undefined function imagecreatefromjpeg() in /var/www/html/classes/ImageManager.php:533\nStack trace:\n#0 /var/www/html/classes/ImageManager.php(260): ImageManagerCore::create(2, '/var/www/html/i...')\n#1 /var/www/html/src/Adapter/Image/ImageRetriever.php(151): ImageManagerCore::resize('/var/www/html/i...', '/var/www/html/i...', 800, 800)\n#2 /var/www/html/src/Adapter/Image/ImageRetriever.php(80): PrestaShop\\PrestaShop\\Adapter\\Image\\ImageRetriever->getImage(Object(Product), '1')\n#3 [internal function]: PrestaShop\\PrestaShop\\Adapter\\Image\\ImageRetriever->PrestaShop\\PrestaShop\\Adapter\\Image\\{closure}(Array)\n#4 /var/www/html/src/Adapter/Image/ImageRetriever.php(90): array_map(Object(Closure), Array)\n#5 /var/www/html/src/Core/Product/ProductPresenter.php(95): PrestaShop\\PrestaShop\\Adapter\\Image\\ImageRetriever->getProductImages(Array, Object(Language))\n#6 /var/www/html/src/Core/Product/ProductPresenter.php(563): PrestaShop\\PrestaShop\\Core\\Product\\ProductPresenter->fillImages(Array, Object(Presta in /var/www/html/classes/ImageManager.php on line 533```
