### PR TITLE
Improve branch docker generation

### DIFF
--- a/Dockerfile-branch.model
+++ b/Dockerfile-branch.model
@@ -4,6 +4,6 @@ LABEL maintainer="PrestaShop Core Team <coreteam@prestashop.com>"
 RUN apt update
 RUN apt -y install git
 
-RUN git clone -b $ps_version https://github.com/PrestaShop/PrestaShop.git /tmp/data-ps
+RUN git clone -b $branch_version https://github.com/PrestaShop/PrestaShop.git /tmp/data-ps
 
 CMD ["/tmp/docker_run.sh"]

--- a/HOW-TO-USE.md
+++ b/HOW-TO-USE.md
@@ -70,3 +70,44 @@ docker compose up generate
 ```
 
 This will create new folders for the new version you just added.
+
+## Running tests locally
+
+To run the python tests you need to install requirements
+
+```bash
+$ pip install -r requirements.txt
+```
+
+Then you can run the tests:
+
+```bash
+$ nosetests
+```
+
+Locally you may have an error like ``, running these commands may help running tests locally:
+
+```bash
+$ pip uninstall -y nose
+$ pip install -U nose --no-binary :all:
+```
+
+or alternatively:
+
+```bash
+$ pip install nose-py3
+```
+
+If you need to debug one specific test you first need to run
+
+```
+$ nosetests --with-id
+```
+
+This will execute tests and each test method will be assigned an ID that you can then use to filter it specifically:
+
+```
+$ nosetests --with-id 7
+```
+
+This will also generate a `.nodeids` binary file, when you add new test methods you need to remove this file to re-generate the list of IDs.

--- a/tests/prestashop_docker/test_generator.py
+++ b/tests/prestashop_docker/test_generator.py
@@ -29,7 +29,7 @@ class GeneratorTestCase(TestCase):
             contents='''
             CONTAINER_VERSION: $container_version
             RUN apt -y install git
-            RUN git clone -b $ps_version https://github.com/PrestaShop/PrestaShop.git /tmp/data-ps
+            RUN git clone -b $branch_version https://github.com/PrestaShop/PrestaShop.git /tmp/data-ps
             '''
         )
 
@@ -46,10 +46,10 @@ class GeneratorTestCase(TestCase):
         self.assertTrue(path.exists('/tmp/images/test'))
 
     def test_generate_image(self):
-        dockerfile = '/tmp/images/1.7.8/7.4-alpine/Dockerfile'
+        dockerfile = '/tmp/images/1.7.8.0/7.4-alpine/Dockerfile'
         self.assertFalse(path.exists(dockerfile))
         self.generator.generate_image(
-            '1.7.8',
+            '1.7.8.0',
             '7.4-alpine'
         )
         self.assertTrue(path.exists(dockerfile))
@@ -58,17 +58,17 @@ class GeneratorTestCase(TestCase):
             content = f.read()
             self.assertIn(
                 'PS_URL: https://www.prestashop.com/download/old/'
-                'prestashop_1.7.8.zip',
+                'prestashop_1.7.8.0.zip',
                 content
             )
-            self.assertIn('PS_VERSION: 1.7.8', content)
+            self.assertIn('PS_VERSION: 1.7.8.0', content)
             self.assertIn('CONTAINER_VERSION: 7.4-alpine', content)
 
-    def test_generate_image_80(self):
-        dockerfile = '/tmp/images/8.0/7.4-alpine/Dockerfile'
+    def test_generate_image_1788(self):
+        dockerfile = '/tmp/images/1.7.8.8/7.4-alpine/Dockerfile'
         self.assertFalse(path.exists(dockerfile))
         self.generator.generate_image(
-            '8.0',
+            '1.7.8.8',
             '7.4-alpine'
         )
         self.assertTrue(path.exists(dockerfile))
@@ -76,11 +76,49 @@ class GeneratorTestCase(TestCase):
         with open(dockerfile) as f:
             content = f.read()
             self.assertIn(
-                'PS_URL: https://github.com/PrestaShop/PrestaShop/releases/download/8.0/'
-                'prestashop_8.0.zip',
+                'PS_URL: https://www.prestashop.com/download/old/'
+                'prestashop_1.7.8.8.zip',
                 content
             )
-            self.assertIn('PS_VERSION: 8.0', content)
+            self.assertIn('PS_VERSION: 1.7.8.8', content)
+            self.assertIn('CONTAINER_VERSION: 7.4-alpine', content)
+
+    def test_generate_image_1789(self):
+        dockerfile = '/tmp/images/1.7.8.9/7.4-alpine/Dockerfile'
+        self.assertFalse(path.exists(dockerfile))
+        self.generator.generate_image(
+            '1.7.8.9',
+            '7.4-alpine'
+        )
+        self.assertTrue(path.exists(dockerfile))
+
+        with open(dockerfile) as f:
+            content = f.read()
+            self.assertIn(
+                'PS_URL: https://github.com/PrestaShop/PrestaShop/releases/download/1.7.8.9/'
+                'prestashop_1.7.8.9.zip',
+                content
+            )
+            self.assertIn('PS_VERSION: 1.7.8.9', content)
+            self.assertIn('CONTAINER_VERSION: 7.4-alpine', content)
+
+    def test_generate_image_80(self):
+        dockerfile = '/tmp/images/8.0.0/7.4-alpine/Dockerfile'
+        self.assertFalse(path.exists(dockerfile))
+        self.generator.generate_image(
+            '8.0.0',
+            '7.4-alpine'
+        )
+        self.assertTrue(path.exists(dockerfile))
+
+        with open(dockerfile) as f:
+            content = f.read()
+            self.assertIn(
+                'PS_URL: https://github.com/PrestaShop/PrestaShop/releases/download/8.0.0/'
+                'prestashop_8.0.0.zip',
+                content
+            )
+            self.assertIn('PS_VERSION: 8.0.0', content)
             self.assertIn('CONTAINER_VERSION: 7.4-alpine', content)
 
     def test_generate_nightly_image(self):
@@ -116,29 +154,42 @@ class GeneratorTestCase(TestCase):
                 'PS_URL',
                 content
             )
-            self.assertNotIn('PS_VERSION', content)
             self.assertIn('CONTAINER_VERSION: 8.1-alpine', content)
             self.assertIn('RUN apt -y install git', content)
             self.assertIn('RUN git clone -b 9.0.x https://github.com/PrestaShop/PrestaShop.git /tmp/data-ps', content)
 
     def test_generate_all(self):
         files = (
-            '/tmp/images/7.0/7.3-apache/Dockerfile',
-            '/tmp/images/7.0/7.3-fpm/Dockerfile',
-            '/tmp/images/7.0/7.2-apache/Dockerfile',
-            '/tmp/images/7.0/7.2-fpm/Dockerfile',
-            '/tmp/images/8.0/7.1-apache/Dockerfile',
-            '/tmp/images/8.0/7.1-fpm/Dockerfile',
-            '/tmp/images/8.0/5.6-apache/Dockerfile',
-            '/tmp/images/8.0/5.6-fpm/Dockerfile',
+            '/tmp/images/1.7.8.8/7.3-apache/Dockerfile',
+            '/tmp/images/1.7.8.8/7.3-fpm/Dockerfile',
+            '/tmp/images/1.7.8.8/7.2-apache/Dockerfile',
+            '/tmp/images/1.7.8.8/7.2-fpm/Dockerfile',
+            '/tmp/images/8.0.0/7.2-apache/Dockerfile',
+            '/tmp/images/8.0.0/7.2-fpm/Dockerfile',
+            '/tmp/images/8.0.0/8.1-apache/Dockerfile',
+            '/tmp/images/8.0.0/8.1-fpm/Dockerfile',
+            '/tmp/images/9.0.x/8.1-apache/Dockerfile',
+            '/tmp/images/9.0.x/8.1-fpm/Dockerfile',
+            '/tmp/images/9.0.x/8.2-apache/Dockerfile',
+            '/tmp/images/9.0.x/8.2-fpm/Dockerfile',
+            '/tmp/images/9.0.x/8.3-apache/Dockerfile',
+            '/tmp/images/9.0.x/8.3-fpm/Dockerfile',
+            '/tmp/images/nightly/8.1-apache/Dockerfile',
+            '/tmp/images/nightly/8.1-fpm/Dockerfile',
+            '/tmp/images/nightly/8.2-apache/Dockerfile',
+            '/tmp/images/nightly/8.2-fpm/Dockerfile',
+            '/tmp/images/nightly/8.3-apache/Dockerfile',
+            '/tmp/images/nightly/8.3-fpm/Dockerfile',
         )
         for f in files:
             self.assertFalse(path.exists(f))
 
         self.generator.generate_all(
             {
-                '7.0': ('7.2', '7.3'),
-                '8.0': ('7.1', '5.6'),
+                '1.7.8.8': ('7.2', '7.3'),
+                '8.0.0': ('7.2', '8.1'),
+                '9.0.x': ('8.1', '8.2', '8.3'),
+                'nightly': ('8.1', '8.2', '8.3'),
             }
         )
 

--- a/tests/prestashop_docker/test_version_manager.py
+++ b/tests/prestashop_docker/test_version_manager.py
@@ -1,6 +1,9 @@
 from pyfakefs.fake_filesystem_unittest import TestCase
 from prestashop_docker.version_manager import VersionManager
 from unittest.mock import patch
+import semver
+# Used for debug
+# import pprint
 
 
 class VersionManagerTestCase(TestCase):
@@ -20,6 +23,10 @@ class VersionManagerTestCase(TestCase):
         self.fs.create_dir('/tmp/images/8.1.0/7.2-fpm')
         self.fs.create_dir('/tmp/images/8.1.3/7.2-apache')
         self.fs.create_dir('/tmp/images/8.1.3/7.2-fpm')
+        self.fs.create_dir('/tmp/images/9.0.x/8.1-fpm')
+        self.fs.create_dir('/tmp/images/9.0.x/8.1-apache')
+        self.fs.create_dir('/tmp/images/9.0.x/8.2-fpm')
+        self.fs.create_dir('/tmp/images/9.0.x/8.2-apache')
         self.fs.create_dir('/tmp/images/nightly/7.1-fpm')
         self.fs.create_dir('/tmp/images/nightly/7.1-apache')
         self.version_manager = self.create_instance()
@@ -35,24 +42,128 @@ class VersionManagerTestCase(TestCase):
         '1.7.6.4': ('5.6', '7.1'),
         '1.7.6.5': ('5.6', '7.1'),
         '1.7.6.8': ('5.6', '7.1', '7.2'),
+        '1.7.6.24': ('5.6', '7.1', '7.2'),
+        '1.7.6.x': ('5.6', '7.1', '7.2'),
         '1.7.7.0-rc.1': ('7.1', '7.2', '7.3'),
         '8.0.0': ('7.2', '7.3', '7.4', '8.0', '8.1'),
         '8.0.0-rc.1': ('7.2', '7.3', '7.4', '8.0', '8.1'),
         '8.1.0': ('7.2', '7.3', '7.4', '8.0', '8.1'),
         '8.1.3': ('7.2', '7.3', '7.4', '8.0', '8.1'),
+        '8.1.x': ('7.2', '7.3', '7.4', '8.0', '8.1'),
+        '9.0.x': ('8.1', '8.2', '8.3'),
         'nightly': ('7.1',)
     }
 
     @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
+    def test_split_prestashop_version(self):
+        result = self.version_manager.split_prestashop_version('8.0.0')
+        self.assertEqual(
+            {'version': '8.0.0', 'major': '8', 'minor': '0', 'patch': '0', 'prerelease': None},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('10.2.24')
+        self.assertEqual(
+            {'version': '10.2.24', 'major': '10', 'minor': '2', 'patch': '24', 'prerelease': None},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('9.0.x')
+        self.assertEqual(
+            {'version': '9.0.x', 'major': '9', 'minor': '0', 'patch': 'x', 'prerelease': None},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('1.7.4.3')
+        self.assertEqual(
+            {'version': '1.7.4.3', 'major': '1.7', 'minor': '4', 'patch': '3', 'prerelease': None},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('1.7.8.x')
+        self.assertEqual(
+            {'version': '1.7.8.x', 'major': '1.7', 'minor': '8', 'patch': 'x', 'prerelease': None},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('1.7.7.0-rc.1')
+        self.assertEqual(
+            {'version': '1.7.7.0', 'major': '1.7', 'minor': '7', 'patch': '0', 'prerelease': 'rc.1'},
+            result
+        )
+        result = self.version_manager.split_prestashop_version('nightly')
+        self.assertEqual(
+            None,
+            result
+        )
+
+    @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
+    def test_get_last_patch_from_version(self):
+        result = self.version_manager.get_last_patch_from_version('1.7.6.4')
+        self.assertEqual(
+            '24',
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('8.0.0')
+        self.assertEqual(
+            '0',
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('8.1.0')
+        self.assertEqual(
+            '3',
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('8.1.3')
+        self.assertEqual(
+            '3',
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('8.1.x')
+        self.assertEqual(
+            '3',
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('9.0.x')
+        self.assertEqual(
+            None,
+            result
+        )
+        result = self.version_manager.get_last_patch_from_version('nightly')
+        self.assertEqual(
+            None,
+            result
+        )
+
+    @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
     def test_get_version_from_string_with_ps_version(self):
+        # Existing patch versions deduce the branch version with a finishing x
         result = self.version_manager.get_version_from_string('1.7.6.8')
         self.assertEqual(
-            {'ps_version': '1.7.6.8', 'php_versions': ('5.6', '7.1', '7.2'), 'container_version': None},
+            {'ps_version': '1.7.6.8', 'branch_version': '1.7.6.x', 'php_versions': ('5.6', '7.1', '7.2'), 'container_version': None},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0')
         self.assertEqual(
-            {'ps_version': '8.0.0', 'php_versions': ('7.2', '7.3', '7.4', '8.0', '8.1'), 'container_version': None},
+            {'ps_version': '8.0.0', 'branch_version': '8.0.x', 'php_versions': ('7.2', '7.3', '7.4', '8.0', '8.1'), 'container_version': None},
+            result
+        )
+        # Branch input return target version patch + 1
+        result = self.version_manager.get_version_from_string('8.1.x')
+        self.assertEqual(
+            {'ps_version': '8.1.4', 'branch_version': '8.1.x', 'php_versions': ('7.2', '7.3', '7.4', '8.0', '8.1'), 'container_version': None},
+            result
+        )
+        result = self.version_manager.get_version_from_string('1.7.6.x')
+        self.assertEqual(
+            {'ps_version': '1.7.6.25', 'branch_version': '1.7.6.x', 'php_versions': ('5.6', '7.1', '7.2'), 'container_version': None},
+            result
+        )
+        # Branch input with no other patch versions returns patch 0
+        result = self.version_manager.get_version_from_string('9.0.x')
+        self.assertEqual(
+            {'ps_version': '9.0.0', 'branch_version': '9.0.x', 'php_versions': ('8.1', '8.2', '8.3'), 'container_version': None},
+            result
+        )
+        # Nightly version uses develop as the branch
+        result = self.version_manager.get_version_from_string('nightly')
+        self.assertEqual(
+            {'ps_version': 'nightly', 'branch_version': 'develop', 'php_versions': ('7.1',), 'container_version': None},
             result
         )
 
@@ -67,12 +178,12 @@ class VersionManagerTestCase(TestCase):
     def test_get_version_from_string_with_container_version(self):
         result = self.version_manager.get_version_from_string('1.7.6.8-5.6')
         self.assertEqual(
-            {'ps_version': '1.7.6.8', 'php_versions': ('5.6',), 'container_version': None},
+            {'ps_version': '1.7.6.8', 'branch_version': '1.7.6.x', 'php_versions': ('5.6',), 'container_version': None},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0-7.2')
         self.assertEqual(
-            {'ps_version': '8.0.0', 'php_versions': ('7.2',), 'container_version': None},
+            {'ps_version': '8.0.0', 'branch_version': '8.0.x', 'php_versions': ('7.2',), 'container_version': None},
             result
         )
 
@@ -80,12 +191,12 @@ class VersionManagerTestCase(TestCase):
     def test_get_version_from_string_with_container_version_and_type(self):
         result = self.version_manager.get_version_from_string('1.7.6.8-5.6-fpm')
         self.assertEqual(
-            {'ps_version': '1.7.6.8', 'php_versions': ('5.6',), 'container_version': 'fpm'},
+            {'ps_version': '1.7.6.8', 'branch_version': '1.7.6.x', 'php_versions': ('5.6',), 'container_version': 'fpm'},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0-7.2-fpm')
         self.assertEqual(
-            {'ps_version': '8.0.0', 'php_versions': ('7.2',), 'container_version': 'fpm'},
+            {'ps_version': '8.0.0', 'branch_version': '8.0.x', 'php_versions': ('7.2',), 'container_version': 'fpm'},
             result
         )
 
@@ -93,12 +204,12 @@ class VersionManagerTestCase(TestCase):
     def test_get_version_from_string_with_pre_release_and_without_container_version_and_type(self):
         result = self.version_manager.get_version_from_string('1.7.7.0-rc.1')
         self.assertEqual(
-            {'ps_version': '1.7.7.0-rc.1', 'php_versions': ('7.1', '7.2', '7.3'), 'container_version': None},
+            {'ps_version': '1.7.7.0-rc.1', 'branch_version': '1.7.7.x', 'php_versions': ('7.1', '7.2', '7.3'), 'container_version': None},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0-rc.1')
         self.assertEqual(
-            {'ps_version': '8.0.0-rc.1', 'php_versions': ('7.2', '7.3', '7.4', '8.0', '8.1'), 'container_version': None},
+            {'ps_version': '8.0.0-rc.1', 'branch_version': '8.0.x', 'php_versions': ('7.2', '7.3', '7.4', '8.0', '8.1'), 'container_version': None},
             result
         )
 
@@ -106,12 +217,12 @@ class VersionManagerTestCase(TestCase):
     def test_get_version_from_string_with_pre_release_and_php_version_and_without_container_version(self):
         result = self.version_manager.get_version_from_string('1.7.7.0-rc.1-7.3')
         self.assertEqual(
-            {'ps_version': '1.7.7.0-rc.1', 'php_versions': ('7.3',), 'container_version': None},
+            {'ps_version': '1.7.7.0-rc.1', 'branch_version': '1.7.7.x', 'php_versions': ('7.3',), 'container_version': None},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0-rc.1-7.3')
         self.assertEqual(
-            {'ps_version': '8.0.0-rc.1', 'php_versions': ('7.3',), 'container_version': None},
+            {'ps_version': '8.0.0-rc.1', 'branch_version': '8.0.x', 'php_versions': ('7.3',), 'container_version': None},
             result
         )
 
@@ -119,12 +230,12 @@ class VersionManagerTestCase(TestCase):
     def test_get_version_from_string_with_pre_release_and_php_version_and_with_container_version(self):
         result = self.version_manager.get_version_from_string('1.7.7.0-rc.1-7.3-apache')
         self.assertEqual(
-            {'ps_version': '1.7.7.0-rc.1', 'php_versions': ('7.3',), 'container_version': 'apache'},
+            {'ps_version': '1.7.7.0-rc.1', 'branch_version': '1.7.7.x', 'php_versions': ('7.3',), 'container_version': 'apache'},
             result
         )
         result = self.version_manager.get_version_from_string('8.0.0-rc.1-7.3-apache')
         self.assertEqual(
-            {'ps_version': '8.0.0-rc.1', 'php_versions': ('7.3',), 'container_version': 'apache'},
+            {'ps_version': '8.0.0-rc.1', 'branch_version': '8.0.x', 'php_versions': ('7.3',), 'container_version': 'apache'},
             result
         )
 
@@ -188,176 +299,308 @@ class VersionManagerTestCase(TestCase):
 
     @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
     def test_get_versions(self):
-        print(self.version_manager.get_versions())
-        self.assertEqual(
-            {
-                '1.7.5.0-5.6-fpm': '/tmp/images/1.7.5.0/5.6-fpm',
-                '1.7.5.0-5.6-apache': '/tmp/images/1.7.5.0/5.6-apache',
-                '1.7.5.0-5.4-fpm': '/tmp/images/1.7.5.0/5.4-fpm',
-                '1.7.5.0-5.4-apache': '/tmp/images/1.7.5.0/5.4-apache',
-                '1.7.5.1-5.6-fpm': '/tmp/images/1.7.5.1/5.6-fpm',
-                '1.7.5.1-5.6-apache': '/tmp/images/1.7.5.1/5.6-apache',
-                '1.7.5.1-5.4-fpm': '/tmp/images/1.7.5.1/5.4-fpm',
-                '1.7.5.1-5.4-apache': '/tmp/images/1.7.5.1/5.4-apache',
-                '1.7.6.4-5.6-fpm': '/tmp/images/1.7.6.4/5.6-fpm',
-                '1.7.6.4-5.6-apache': '/tmp/images/1.7.6.4/5.6-apache',
-                '1.7.6.4-7.1-fpm': '/tmp/images/1.7.6.4/7.1-fpm',
-                '1.7.6.4-7.1-apache': '/tmp/images/1.7.6.4/7.1-apache',
-                '1.7.6.5-5.6-fpm': '/tmp/images/1.7.6.5/5.6-fpm',
-                '1.7.6.5-5.6-apache': '/tmp/images/1.7.6.5/5.6-apache',
-                '1.7.6.5-7.1-fpm': '/tmp/images/1.7.6.5/7.1-fpm',
-                '1.7.6.5-7.1-apache': '/tmp/images/1.7.6.5/7.1-apache',
-                '1.7.6.8-5.6-fpm': '/tmp/images/1.7.6.8/5.6-fpm',
-                '1.7.6.8-5.6-apache': '/tmp/images/1.7.6.8/5.6-apache',
-                '1.7.6.8-7.1-fpm': '/tmp/images/1.7.6.8/7.1-fpm',
-                '1.7.6.8-7.1-apache': '/tmp/images/1.7.6.8/7.1-apache',
-                '1.7.6.8-7.2-fpm': '/tmp/images/1.7.6.8/7.2-fpm',
-                '1.7.6.8-7.2-apache': '/tmp/images/1.7.6.8/7.2-apache',
-                '1.7.7.0-rc.1-7.1-fpm': '/tmp/images/1.7.7.0-rc.1/7.1-fpm',
-                '1.7.7.0-rc.1-7.1-apache': '/tmp/images/1.7.7.0-rc.1/7.1-apache',
-                '1.7.7.0-rc.1-7.2-fpm': '/tmp/images/1.7.7.0-rc.1/7.2-fpm',
-                '1.7.7.0-rc.1-7.2-apache': '/tmp/images/1.7.7.0-rc.1/7.2-apache',
-                '1.7.7.0-rc.1-7.3-fpm': '/tmp/images/1.7.7.0-rc.1/7.3-fpm',
-                '1.7.7.0-rc.1-7.3-apache': '/tmp/images/1.7.7.0-rc.1/7.3-apache',
-                '8.0.0-7.2-fpm': '/tmp/images/8.0.0/7.2-fpm',
-                '8.0.0-7.2-apache': '/tmp/images/8.0.0/7.2-apache',
-                '8.0.0-7.3-fpm': '/tmp/images/8.0.0/7.3-fpm',
-                '8.0.0-7.3-apache': '/tmp/images/8.0.0/7.3-apache',
-                '8.0.0-7.4-fpm': '/tmp/images/8.0.0/7.4-fpm',
-                '8.0.0-7.4-apache': '/tmp/images/8.0.0/7.4-apache',
-                '8.0.0-8.0-fpm': '/tmp/images/8.0.0/8.0-fpm',
-                '8.0.0-8.0-apache': '/tmp/images/8.0.0/8.0-apache',
-                '8.0.0-8.1-fpm': '/tmp/images/8.0.0/8.1-fpm',
-                '8.0.0-8.1-apache': '/tmp/images/8.0.0/8.1-apache',
-                '8.0.0-rc.1-7.2-fpm': '/tmp/images/8.0.0-rc.1/7.2-fpm',
-                '8.0.0-rc.1-7.2-apache': '/tmp/images/8.0.0-rc.1/7.2-apache',
-                '8.0.0-rc.1-7.3-fpm': '/tmp/images/8.0.0-rc.1/7.3-fpm',
-                '8.0.0-rc.1-7.3-apache': '/tmp/images/8.0.0-rc.1/7.3-apache',
-                '8.0.0-rc.1-7.4-fpm': '/tmp/images/8.0.0-rc.1/7.4-fpm',
-                '8.0.0-rc.1-7.4-apache': '/tmp/images/8.0.0-rc.1/7.4-apache',
-                '8.0.0-rc.1-8.0-fpm': '/tmp/images/8.0.0-rc.1/8.0-fpm',
-                '8.0.0-rc.1-8.0-apache': '/tmp/images/8.0.0-rc.1/8.0-apache',
-                '8.0.0-rc.1-8.1-fpm': '/tmp/images/8.0.0-rc.1/8.1-fpm',
-                '8.0.0-rc.1-8.1-apache': '/tmp/images/8.0.0-rc.1/8.1-apache',
-                '8.1.0-7.2-fpm': '/tmp/images/8.1.0/7.2-fpm',
-                '8.1.0-7.2-apache': '/tmp/images/8.1.0/7.2-apache',
-                '8.1.0-7.3-fpm': '/tmp/images/8.1.0/7.3-fpm',
-                '8.1.0-7.3-apache': '/tmp/images/8.1.0/7.3-apache',
-                '8.1.0-7.4-fpm': '/tmp/images/8.1.0/7.4-fpm',
-                '8.1.0-7.4-apache': '/tmp/images/8.1.0/7.4-apache',
-                '8.1.0-8.0-fpm': '/tmp/images/8.1.0/8.0-fpm',
-                '8.1.0-8.0-apache': '/tmp/images/8.1.0/8.0-apache',
-                '8.1.0-8.1-fpm': '/tmp/images/8.1.0/8.1-fpm',
-                '8.1.0-8.1-apache': '/tmp/images/8.1.0/8.1-apache',
-                '8.1.0-7.2-fpm': '/tmp/images/8.1.0/7.2-fpm',
-                '8.1.3-7.2-fpm': '/tmp/images/8.1.3/7.2-fpm',
-                '8.1.3-7.2-apache': '/tmp/images/8.1.3/7.2-apache',
-                '8.1.3-7.3-fpm': '/tmp/images/8.1.3/7.3-fpm',
-                '8.1.3-7.3-apache': '/tmp/images/8.1.3/7.3-apache',
-                '8.1.3-7.4-fpm': '/tmp/images/8.1.3/7.4-fpm',
-                '8.1.3-7.4-apache': '/tmp/images/8.1.3/7.4-apache',
-                '8.1.3-8.0-fpm': '/tmp/images/8.1.3/8.0-fpm',
-                '8.1.3-8.0-apache': '/tmp/images/8.1.3/8.0-apache',
-                '8.1.3-8.1-fpm': '/tmp/images/8.1.3/8.1-fpm',
-                '8.1.3-8.1-apache': '/tmp/images/8.1.3/8.1-apache',
-                'nightly-7.1-fpm': '/tmp/images/nightly/7.1-fpm',
-                'nightly-7.1-apache': '/tmp/images/nightly/7.1-apache'
+        manager_versions = self.version_manager.get_versions()
+        expected_versions = {
+            '1.7.5.0-5.6-fpm': '/tmp/images/1.7.5.0/5.6-fpm',
+            '1.7.5.0-5.6-apache': '/tmp/images/1.7.5.0/5.6-apache',
+            '1.7.5.0-5.4-fpm': '/tmp/images/1.7.5.0/5.4-fpm',
+            '1.7.5.0-5.4-apache': '/tmp/images/1.7.5.0/5.4-apache',
+            '1.7.5.1-5.6-fpm': '/tmp/images/1.7.5.1/5.6-fpm',
+            '1.7.5.1-5.6-apache': '/tmp/images/1.7.5.1/5.6-apache',
+            '1.7.5.1-5.4-fpm': '/tmp/images/1.7.5.1/5.4-fpm',
+            '1.7.5.1-5.4-apache': '/tmp/images/1.7.5.1/5.4-apache',
+            '1.7.6.4-5.6-fpm': '/tmp/images/1.7.6.4/5.6-fpm',
+            '1.7.6.4-5.6-apache': '/tmp/images/1.7.6.4/5.6-apache',
+            '1.7.6.4-7.1-fpm': '/tmp/images/1.7.6.4/7.1-fpm',
+            '1.7.6.4-7.1-apache': '/tmp/images/1.7.6.4/7.1-apache',
+            '1.7.6.5-5.6-fpm': '/tmp/images/1.7.6.5/5.6-fpm',
+            '1.7.6.5-5.6-apache': '/tmp/images/1.7.6.5/5.6-apache',
+            '1.7.6.5-7.1-fpm': '/tmp/images/1.7.6.5/7.1-fpm',
+            '1.7.6.5-7.1-apache': '/tmp/images/1.7.6.5/7.1-apache',
+            '1.7.6.8-5.6-fpm': '/tmp/images/1.7.6.8/5.6-fpm',
+            '1.7.6.8-5.6-apache': '/tmp/images/1.7.6.8/5.6-apache',
+            '1.7.6.8-7.1-fpm': '/tmp/images/1.7.6.8/7.1-fpm',
+            '1.7.6.8-7.1-apache': '/tmp/images/1.7.6.8/7.1-apache',
+            '1.7.6.8-7.2-fpm': '/tmp/images/1.7.6.8/7.2-fpm',
+            '1.7.6.8-7.2-apache': '/tmp/images/1.7.6.8/7.2-apache',
+            '1.7.6.24-5.6-fpm': '/tmp/images/1.7.6.24/5.6-fpm',
+            '1.7.6.24-5.6-apache': '/tmp/images/1.7.6.24/5.6-apache',
+            '1.7.6.24-7.1-fpm': '/tmp/images/1.7.6.24/7.1-fpm',
+            '1.7.6.24-7.1-apache': '/tmp/images/1.7.6.24/7.1-apache',
+            '1.7.6.24-7.2-fpm': '/tmp/images/1.7.6.24/7.2-fpm',
+            '1.7.6.24-7.2-apache': '/tmp/images/1.7.6.24/7.2-apache',
+            '1.7.6.x-5.6-fpm': '/tmp/images/1.7.6.x/5.6-fpm',
+            '1.7.6.x-5.6-apache': '/tmp/images/1.7.6.x/5.6-apache',
+            '1.7.6.x-7.1-fpm': '/tmp/images/1.7.6.x/7.1-fpm',
+            '1.7.6.x-7.1-apache': '/tmp/images/1.7.6.x/7.1-apache',
+            '1.7.6.x-7.2-fpm': '/tmp/images/1.7.6.x/7.2-fpm',
+            '1.7.6.x-7.2-apache': '/tmp/images/1.7.6.x/7.2-apache',
+            '1.7.7.0-rc.1-7.1-fpm': '/tmp/images/1.7.7.0-rc.1/7.1-fpm',
+            '1.7.7.0-rc.1-7.1-apache': '/tmp/images/1.7.7.0-rc.1/7.1-apache',
+            '1.7.7.0-rc.1-7.2-fpm': '/tmp/images/1.7.7.0-rc.1/7.2-fpm',
+            '1.7.7.0-rc.1-7.2-apache': '/tmp/images/1.7.7.0-rc.1/7.2-apache',
+            '1.7.7.0-rc.1-7.3-fpm': '/tmp/images/1.7.7.0-rc.1/7.3-fpm',
+            '1.7.7.0-rc.1-7.3-apache': '/tmp/images/1.7.7.0-rc.1/7.3-apache',
+            '8.0.0-7.2-fpm': '/tmp/images/8.0.0/7.2-fpm',
+            '8.0.0-7.2-apache': '/tmp/images/8.0.0/7.2-apache',
+            '8.0.0-7.3-fpm': '/tmp/images/8.0.0/7.3-fpm',
+            '8.0.0-7.3-apache': '/tmp/images/8.0.0/7.3-apache',
+            '8.0.0-7.4-fpm': '/tmp/images/8.0.0/7.4-fpm',
+            '8.0.0-7.4-apache': '/tmp/images/8.0.0/7.4-apache',
+            '8.0.0-8.0-fpm': '/tmp/images/8.0.0/8.0-fpm',
+            '8.0.0-8.0-apache': '/tmp/images/8.0.0/8.0-apache',
+            '8.0.0-8.1-fpm': '/tmp/images/8.0.0/8.1-fpm',
+            '8.0.0-8.1-apache': '/tmp/images/8.0.0/8.1-apache',
+            '8.0.0-rc.1-7.2-fpm': '/tmp/images/8.0.0-rc.1/7.2-fpm',
+            '8.0.0-rc.1-7.2-apache': '/tmp/images/8.0.0-rc.1/7.2-apache',
+            '8.0.0-rc.1-7.3-fpm': '/tmp/images/8.0.0-rc.1/7.3-fpm',
+            '8.0.0-rc.1-7.3-apache': '/tmp/images/8.0.0-rc.1/7.3-apache',
+            '8.0.0-rc.1-7.4-fpm': '/tmp/images/8.0.0-rc.1/7.4-fpm',
+            '8.0.0-rc.1-7.4-apache': '/tmp/images/8.0.0-rc.1/7.4-apache',
+            '8.0.0-rc.1-8.0-fpm': '/tmp/images/8.0.0-rc.1/8.0-fpm',
+            '8.0.0-rc.1-8.0-apache': '/tmp/images/8.0.0-rc.1/8.0-apache',
+            '8.0.0-rc.1-8.1-fpm': '/tmp/images/8.0.0-rc.1/8.1-fpm',
+            '8.0.0-rc.1-8.1-apache': '/tmp/images/8.0.0-rc.1/8.1-apache',
+            '8.1.0-7.2-fpm': '/tmp/images/8.1.0/7.2-fpm',
+            '8.1.0-7.2-apache': '/tmp/images/8.1.0/7.2-apache',
+            '8.1.0-7.3-fpm': '/tmp/images/8.1.0/7.3-fpm',
+            '8.1.0-7.3-apache': '/tmp/images/8.1.0/7.3-apache',
+            '8.1.0-7.4-fpm': '/tmp/images/8.1.0/7.4-fpm',
+            '8.1.0-7.4-apache': '/tmp/images/8.1.0/7.4-apache',
+            '8.1.0-8.0-fpm': '/tmp/images/8.1.0/8.0-fpm',
+            '8.1.0-8.0-apache': '/tmp/images/8.1.0/8.0-apache',
+            '8.1.0-8.1-fpm': '/tmp/images/8.1.0/8.1-fpm',
+            '8.1.0-8.1-apache': '/tmp/images/8.1.0/8.1-apache',
+            '8.1.0-7.2-fpm': '/tmp/images/8.1.0/7.2-fpm',
+            '8.1.3-7.2-fpm': '/tmp/images/8.1.3/7.2-fpm',
+            '8.1.3-7.2-apache': '/tmp/images/8.1.3/7.2-apache',
+            '8.1.3-7.3-fpm': '/tmp/images/8.1.3/7.3-fpm',
+            '8.1.3-7.3-apache': '/tmp/images/8.1.3/7.3-apache',
+            '8.1.3-7.4-fpm': '/tmp/images/8.1.3/7.4-fpm',
+            '8.1.3-7.4-apache': '/tmp/images/8.1.3/7.4-apache',
+            '8.1.3-8.0-fpm': '/tmp/images/8.1.3/8.0-fpm',
+            '8.1.3-8.0-apache': '/tmp/images/8.1.3/8.0-apache',
+            '8.1.3-8.1-fpm': '/tmp/images/8.1.3/8.1-fpm',
+            '8.1.3-8.1-apache': '/tmp/images/8.1.3/8.1-apache',
+            '8.1.x-7.2-fpm': '/tmp/images/8.1.x/7.2-fpm',
+            '8.1.x-7.2-apache': '/tmp/images/8.1.x/7.2-apache',
+            '8.1.x-7.3-fpm': '/tmp/images/8.1.x/7.3-fpm',
+            '8.1.x-7.3-apache': '/tmp/images/8.1.x/7.3-apache',
+            '8.1.x-7.4-fpm': '/tmp/images/8.1.x/7.4-fpm',
+            '8.1.x-7.4-apache': '/tmp/images/8.1.x/7.4-apache',
+            '8.1.x-8.0-fpm': '/tmp/images/8.1.x/8.0-fpm',
+            '8.1.x-8.0-apache': '/tmp/images/8.1.x/8.0-apache',
+            '8.1.x-8.1-fpm': '/tmp/images/8.1.x/8.1-fpm',
+            '8.1.x-8.1-apache': '/tmp/images/8.1.x/8.1-apache',
+            '9.0.x-8.1-fpm': '/tmp/images/9.0.x/8.1-fpm',
+            '9.0.x-8.1-apache': '/tmp/images/9.0.x/8.1-apache',
+            '9.0.x-8.2-fpm': '/tmp/images/9.0.x/8.2-fpm',
+            '9.0.x-8.2-apache': '/tmp/images/9.0.x/8.2-apache',
+            '9.0.x-8.3-fpm': '/tmp/images/9.0.x/8.3-fpm',
+            '9.0.x-8.3-apache': '/tmp/images/9.0.x/8.3-apache',
+            'nightly-7.1-fpm': '/tmp/images/nightly/7.1-fpm',
+            'nightly-7.1-apache': '/tmp/images/nightly/7.1-apache',
+        }
+        # Useful for debug
+        # pprint.pp(manager_versions)
+        # pprint.pp(expected_versions)
+        # diff = list(set(manager_versions) - set(expected_versions))
+        # print(diff)
 
+        self.assertEqual(expected_versions, manager_versions)
+
+    @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
+    def test_get_ps_versions_aliases(self):
+        expected_versions_aliases = {
+            '1.7': {
+                'version': semver.VersionInfo(7, 6, 24), 'value': '1.7.6.24'
             },
+            '1.7.5': {
+                'version': semver.VersionInfo(7, 5, 1), 'value': '1.7.5.1'
+            },
+            '1.7.5.1': {
+                'version': semver.VersionInfo(7, 5, 1), 'value': '1.7.5.1'
+            },
+            'latest': {
+                'version': semver.VersionInfo(8, 1, 3), 'value': '8.1.3'
+            },
+            '1.7.6': {
+                'version': semver.VersionInfo(7, 6, 24), 'value': '1.7.6.24'
+            },
+            '1.7.6.4': {
+                'version': semver.VersionInfo(7, 6, 4), 'value': '1.7.6.4'
+            },
+            '1.7.6.5': {
+                'version': semver.VersionInfo(7, 6, 5), 'value': '1.7.6.5'
+            },
+            '1.7.6.8': {
+                'version': semver.VersionInfo(7, 6, 8), 'value': '1.7.6.8'
+            },
+            '1.7.6.24': {
+                'version': semver.VersionInfo(7, 6, 24), 'value': '1.7.6.24'
+            },
+            '1.7.6.x': {
+                'value': '1.7.6.x'
+            },
+            '1.7.7.0-rc.1': {
+                'value': '1.7.7.0-rc.1'
+            },
+            '8': {
+                'version': semver.VersionInfo(8, 1, 3), 'value': '8.1.3'
+            },
+            '8.0': {
+                'version': semver.VersionInfo(8, 0, 0), 'value': '8.0.0'
+            },
+            '8.0.0': {
+                'version': semver.VersionInfo(8, 0, 0), 'value': '8.0.0'
+            },
+            '8.0.0-rc.1': {
+                'value': '8.0.0-rc.1'
+            },
+            '8.1': {
+                'version': semver.VersionInfo(8, 1, 3), 'value': '8.1.3'
+            },
+            '8.1.0': {
+                'version': semver.VersionInfo(8, 1, 0), 'value': '8.1.0'
+            },
+            '8.1.3': {
+                'version': semver.VersionInfo(8, 1, 3), 'value': '8.1.3'
+            },
+            '8.1.x': {
+                'value': '8.1.x'
+            },
+            '9.0.x': {
+                'value': '9.0.x'
+            },
+            'nightly': {
+                'value': 'nightly'
+            },
+        }
+        manager_versions_aliases = self.version_manager.get_ps_versions_aliases()
+        # Useful for debug
+        # pprint.pp(manager_versions_aliases)
+        # pprint.pp(expected_versions_aliases)
 
-            self.version_manager.get_versions(),
-        )
+        self.assertEqual(expected_versions_aliases, manager_versions_aliases)
 
     @patch('prestashop_docker.version_manager.VERSIONS', all_versions)
     def test_get_aliases(self):
+        expected_aliases = {
+            '1.7.6.24-5.6-apache': ['1.7-5.6', '1.7.6-5.6', '1.7.6.24-5.6'],
+            '1.7.6.24-7.1-apache': ['1.7-7.1', '1.7.6-7.1', '1.7.6.24-7.1'],
+            '1.7.6.24-7.2-apache': [
+                '1.7-7.2',
+                '1.7',
+                '1.7-apache',
+                '1.7.6-7.2',
+                '1.7.6',
+                '1.7.6-apache',
+                '1.7.6.24-7.2',
+                '1.7.6.24',
+                '1.7.6.24-apache',
+            ],
+            '1.7.6.24-7.2-fpm': ['1.7-fpm', '1.7.6-fpm', '1.7.6.24-fpm'],
+            '1.7.6.8-5.6-apache': ['1.7.6.8-5.6'],
+            '1.7.6.8-7.1-apache': ['1.7.6.8-7.1'],
+            '1.7.6.8-7.2-apache': ['1.7.6.8-7.2', '1.7.6.8', '1.7.6.8-apache'],
+            '1.7.6.8-7.2-fpm': ['1.7.6.8-fpm'],
+            '1.7.6.x-5.6-apache': ['1.7.6.x-5.6'],
+            '1.7.6.x-7.1-apache': ['1.7.6.x-7.1'],
+            '1.7.6.x-7.2-apache': ['1.7.6.x-7.2', '1.7.6.x', '1.7.6.x-apache'],
+            '1.7.6.x-7.2-fpm': ['1.7.6.x-fpm'],
+            '1.7.5.1-5.6-apache': [
+                '1.7.5-5.6',
+                '1.7.5',
+                '1.7.5-apache',
+                '1.7.5.1-5.6',
+                '1.7.5.1',
+                '1.7.5.1-apache',
+            ],
+            '1.7.5.1-5.4-apache': ['1.7.5-5.4', '1.7.5.1-5.4'],
+            '1.7.5.1-5.6-fpm': ['1.7.5-fpm', '1.7.5.1-fpm'],
+            '1.7.6.4-5.6-apache': ['1.7.6.4-5.6'],
+            '1.7.6.4-7.1-apache': ['1.7.6.4-7.1', '1.7.6.4', '1.7.6.4-apache'],
+            '1.7.6.4-7.1-fpm': ['1.7.6.4-fpm'],
+            '1.7.6.5-5.6-apache': ['1.7.6.5-5.6'],
+            '1.7.6.5-7.1-apache': ['1.7.6.5-7.1', '1.7.6.5', '1.7.6.5-apache'],
+            '1.7.6.5-7.1-fpm': ['1.7.6.5-fpm'],
+            '1.7.7.0-rc.1-7.1-apache': ['1.7.7.0-rc.1-7.1'],
+            '1.7.7.0-rc.1-7.2-apache': ['1.7.7.0-rc.1-7.2'],
+            '1.7.7.0-rc.1-7.3-apache': [
+                '1.7.7.0-rc.1-7.3',
+                '1.7.7.0-rc.1',
+                '1.7.7.0-rc.1-apache',
+            ],
+            '1.7.7.0-rc.1-7.3-fpm': ['1.7.7.0-rc.1-fpm'],
+            '8.0.0-7.2-apache': ['8.0-7.2', '8.0.0-7.2'],
+            '8.0.0-7.3-apache': ['8.0-7.3', '8.0.0-7.3'],
+            '8.0.0-7.4-apache': ['8.0-7.4', '8.0.0-7.4'],
+            '8.0.0-8.0-apache': ['8.0-8.0', '8.0.0-8.0'],
+            '8.0.0-8.1-apache': [
+                '8.0-8.1',
+                '8.0',
+                '8.0-apache',
+                '8.0.0-8.1',
+                '8.0.0',
+                '8.0.0-apache'
+            ],
+            '8.0.0-8.1-fpm': ['8.0-fpm', '8.0.0-fpm'],
+            '8.0.0-rc.1-7.2-apache': ['8.0.0-rc.1-7.2'],
+            '8.0.0-rc.1-7.3-apache': ['8.0.0-rc.1-7.3'],
+            '8.0.0-rc.1-7.4-apache': ['8.0.0-rc.1-7.4'],
+            '8.0.0-rc.1-8.0-apache': ['8.0.0-rc.1-8.0'],
+            '8.0.0-rc.1-8.1-apache': [
+                '8.0.0-rc.1-8.1',
+                '8.0.0-rc.1',
+                '8.0.0-rc.1-apache'
+            ],
+            '8.0.0-rc.1-8.1-fpm': ['8.0.0-rc.1-fpm'],
+            '8.1.0-7.2-apache': ['8.1.0-7.2'],
+            '8.1.0-7.3-apache': ['8.1.0-7.3'],
+            '8.1.0-7.4-apache': ['8.1.0-7.4'],
+            '8.1.0-8.0-apache': ['8.1.0-8.0'],
+            '8.1.0-8.1-apache': ['8.1.0-8.1', '8.1.0', '8.1.0-apache'],
+            '8.1.0-8.1-fpm': ['8.1.0-fpm'],
+            '8.1.3-7.2-apache': ['8-7.2', '8.1-7.2', '8.1.3-7.2'],
+            '8.1.3-7.3-apache': ['8-7.3', '8.1-7.3', '8.1.3-7.3'],
+            '8.1.3-7.4-apache': ['8-7.4', '8.1-7.4', '8.1.3-7.4'],
+            '8.1.3-8.0-apache': ['8-8.0', '8.1-8.0', '8.1.3-8.0'],
+            '8.1.3-8.1-apache': [
+                'latest',
+                '8-8.1',
+                '8',
+                '8-apache',
+                '8.1-8.1',
+                '8.1',
+                '8.1-apache',
+                '8.1.3-8.1',
+                '8.1.3',
+                '8.1.3-apache',
+            ],
+            '8.1.3-8.1-fpm': ['8-fpm', '8.1-fpm', '8.1.3-fpm'],
+            '8.1.x-7.2-apache': ['8.1.x-7.2'],
+            '8.1.x-7.3-apache': ['8.1.x-7.3'],
+            '8.1.x-7.4-apache': ['8.1.x-7.4'],
+            '8.1.x-8.0-apache': ['8.1.x-8.0'],
+            '8.1.x-8.1-apache': ['8.1.x-8.1', '8.1.x', '8.1.x-apache'],
+            '8.1.x-8.1-fpm': ['8.1.x-fpm'],
+            '9.0.x-8.1-apache': ['9.0.x-8.1'],
+            '9.0.x-8.2-apache': ['9.0.x-8.2'],
+            '9.0.x-8.3-apache': ['9.0.x-8.3', '9.0.x', '9.0.x-apache'],
+            '9.0.x-8.3-fpm': ['9.0.x-fpm'],
+            'nightly-7.1-apache': ['nightly-7.1', 'nightly', 'nightly-apache'],
+            'nightly-7.1-fpm': ['nightly-fpm'],
+        }
+        manager_aliases = self.version_manager.get_aliases()
+        # Useful for debug
+        # print('### manager')
+        # pprint.pp(manager_aliases)
+        # print('### expected')
+        # pprint.pp(expected_aliases)
+        # diff = list(set(manager_aliases) - set(expected_aliases))
+        # print(diff)
+
         self.assertEqual(
-            {
-                '1.7.6.8-5.6-apache': ['1.7-5.6', '1.7.6-5.6', '1.7.6.8-5.6'],
-                '1.7.6.8-7.1-apache': ['1.7-7.1', '1.7.6-7.1', '1.7.6.8-7.1'],
-                '1.7.6.8-7.2-apache': [
-                    '1.7-7.2',
-                    '1.7',
-                    '1.7-apache',
-                    '1.7.6-7.2',
-                    '1.7.6',
-                    '1.7.6-apache',
-                    '1.7.6.8-7.2',
-                    '1.7.6.8',
-                    '1.7.6.8-apache',
-                ],
-                '1.7.6.8-7.2-fpm': ['1.7-fpm', '1.7.6-fpm', '1.7.6.8-fpm'],
-                '1.7.5.1-5.6-apache': [
-                    '1.7.5-5.6',
-                    '1.7.5',
-                    '1.7.5-apache',
-                    '1.7.5.1-5.6',
-                    '1.7.5.1',
-                    '1.7.5.1-apache',
-                ],
-                '1.7.5.1-5.4-apache': ['1.7.5-5.4', '1.7.5.1-5.4'],
-                '1.7.5.1-5.6-fpm': ['1.7.5-fpm', '1.7.5.1-fpm'],
-                '1.7.6.4-5.6-apache': ['1.7.6.4-5.6'],
-                '1.7.6.4-7.1-apache': ['1.7.6.4-7.1', '1.7.6.4', '1.7.6.4-apache'],
-                '1.7.6.4-7.1-fpm': ['1.7.6.4-fpm'],
-                '1.7.6.5-5.6-apache': ['1.7.6.5-5.6'],
-                '1.7.6.5-7.1-apache': ['1.7.6.5-7.1', '1.7.6.5', '1.7.6.5-apache'],
-                '1.7.6.5-7.1-fpm': ['1.7.6.5-fpm'],
-                '1.7.7.0-rc.1-7.1-apache': ['1.7.7.0-rc.1-7.1'],
-                '1.7.7.0-rc.1-7.2-apache': ['1.7.7.0-rc.1-7.2'],
-                '1.7.7.0-rc.1-7.3-apache': [
-                    '1.7.7.0-rc.1-7.3',
-                    '1.7.7.0-rc.1',
-                    '1.7.7.0-rc.1-apache',
-                ],
-                '1.7.7.0-rc.1-7.3-fpm': ['1.7.7.0-rc.1-fpm'],
-                '8.0.0-7.2-apache': ['8.0-7.2', '8.0.0-7.2'],
-                '8.0.0-7.3-apache': ['8.0-7.3', '8.0.0-7.3'],
-                '8.0.0-7.4-apache': ['8.0-7.4', '8.0.0-7.4'],
-                '8.0.0-8.0-apache': ['8.0-8.0', '8.0.0-8.0'],
-                '8.0.0-8.1-apache': [
-                    '8.0-8.1',
-                    '8.0',
-                    '8.0-apache',
-                    '8.0.0-8.1',
-                    '8.0.0',
-                    '8.0.0-apache'
-                ],
-                '8.0.0-8.1-fpm': ['8.0-fpm', '8.0.0-fpm'],
-                '8.0.0-rc.1-7.2-apache': ['8.0.0-rc.1-7.2'],
-                '8.0.0-rc.1-7.3-apache': ['8.0.0-rc.1-7.3'],
-                '8.0.0-rc.1-7.4-apache': ['8.0.0-rc.1-7.4'],
-                '8.0.0-rc.1-8.0-apache': ['8.0.0-rc.1-8.0'],
-                '8.0.0-rc.1-8.1-apache': [
-                    '8.0.0-rc.1-8.1',
-                    '8.0.0-rc.1',
-                    '8.0.0-rc.1-apache'
-                ],
-                '8.0.0-rc.1-8.1-fpm': ['8.0.0-rc.1-fpm'],
-                '8.1.0-7.2-apache': ['8.1.0-7.2'],
-                '8.1.0-7.3-apache': ['8.1.0-7.3'],
-                '8.1.0-7.4-apache': ['8.1.0-7.4'],
-                '8.1.0-8.0-apache': ['8.1.0-8.0'],
-                '8.1.0-8.1-apache': ['8.1.0-8.1', '8.1.0', '8.1.0-apache'],
-                '8.1.0-8.1-fpm': ['8.1.0-fpm'],
-                '8.1.3-7.2-apache': ['8-7.2', '8.1-7.2', '8.1.3-7.2'],
-                '8.1.3-7.3-apache': ['8-7.3', '8.1-7.3', '8.1.3-7.3'],
-                '8.1.3-7.4-apache': ['8-7.4', '8.1-7.4', '8.1.3-7.4'],
-                '8.1.3-8.0-apache': ['8-8.0', '8.1-8.0', '8.1.3-8.0'],
-                '8.1.3-8.1-apache': [
-                    'latest',
-                    '8-8.1',
-                    '8',
-                    '8-apache',
-                    '8.1-8.1',
-                    '8.1',
-                    '8.1-apache',
-                    '8.1.3-8.1',
-                    '8.1.3',
-                    '8.1.3-apache',
-                ],
-                '8.1.3-8.1-fpm': ['8-fpm', '8.1-fpm', '8.1.3-fpm'],
-                'nightly-7.1-apache': ['nightly-7.1', 'nightly', 'nightly-apache'],
-                'nightly-7.1-fpm': ['nightly-fpm'],
-            },
-            self.version_manager.get_aliases(),
+            expected_aliases,
+            manager_aliases,
         )


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The recent new feature that aims at building a docker for 9.0.x failed at the building phase, mostly because `semver.VersionInfo.parse` cannot parse `9.0.x` as it is not a valid version So some refacto was needed to handle these custom branch versions, the tests were updated accordingly to be sure we don't break this new feature in the future
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
