### PR TITLE
Update test checking a shop is already installed, because settings.inc.php is not created anymore on PS v9

### DIFF
--- a/base/config_files/docker_run.sh
+++ b/base/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.1-apache/config_files/docker_run.sh
+++ b/base/images/7.1-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.1-fpm/config_files/docker_run.sh
+++ b/base/images/7.1-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.2-apache/config_files/docker_run.sh
+++ b/base/images/7.2-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.2-fpm/config_files/docker_run.sh
+++ b/base/images/7.2-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.3-apache/config_files/docker_run.sh
+++ b/base/images/7.3-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.3-fpm/config_files/docker_run.sh
+++ b/base/images/7.3-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.4-apache/config_files/docker_run.sh
+++ b/base/images/7.4-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/7.4-fpm/config_files/docker_run.sh
+++ b/base/images/7.4-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.0-apache/config_files/docker_run.sh
+++ b/base/images/8.0-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.0-fpm/config_files/docker_run.sh
+++ b/base/images/8.0-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.1-apache/config_files/docker_run.sh
+++ b/base/images/8.1-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.1-fpm/config_files/docker_run.sh
+++ b/base/images/8.1-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.2-apache/config_files/docker_run.sh
+++ b/base/images/8.2-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.2-fpm/config_files/docker_run.sh
+++ b/base/images/8.2-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.3-apache/config_files/docker_run.sh
+++ b/base/images/8.3-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.3-fpm/config_files/docker_run.sh
+++ b/base/images/8.3-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.4-apache/config_files/docker_run.sh
+++ b/base/images/8.4-apache/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10

--- a/base/images/8.4-fpm/config_files/docker_run.sh
+++ b/base/images/8.4-fpm/config_files/docker_run.sh
@@ -22,7 +22,7 @@ fi
 # From now, stop at error
 set -e
 
-if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
+if [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] &&  [ ! -f ./install.lock ]; then
 
     echo "\n* Setting up install lock file..."
     touch ./install.lock
@@ -113,13 +113,13 @@ if [ ! -f ./config/settings.inc.php ] && [ ! -f ./install.lock ]; then
     echo "\n* Setup completed, removing lock file..."
     rm ./install.lock
 
-elif [ ! -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ ! -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Another setup is currently running..."
     sleep 10
     exit 42
 
-elif [ -f ./config/settings.inc.php ] && [ -f ./install.lock ]; then
+elif [ -f ./config/settings.inc.php ] && [ ! -f ./app/config/parameters.php ] && [ -f ./install.lock ]; then
 
     echo "\n* Shop seems setup but remaining install lock still present..."
     sleep 10


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `config/settings.inc.php` is not created anymore on PS v9+. In consequence, the tag `nightly` will reinstall PrestaShop at each startup because it will wrongly think the shop is not installed.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/pull/37418
| Sponsor company   | /
| How to test?      | Install a shop with the tag `nightly`. When you restart it, the container should not reinstall PrestaShop.
