### PR TITLE
Enable build of multi-platform images (amd64, arm32 & arm64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish containers
+name: Publish images
 
 on:
   push:
@@ -7,8 +7,26 @@ on:
       - master
 
 jobs:
-  publish_base:
+  list_base_images:
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.set-versions.outputs.versions }}
+      base_has_changed: ${{ steps.changes.outputs.base }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-versions
+        run: echo "versions=$(ls base/images/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            base:
+              - 'base/**'
+
+  list_prestashop_images:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.set-versions.outputs.versions }}
     steps:
       # Fetch versions to work for images
       - uses: actions/checkout@v2
@@ -19,51 +37,57 @@ jobs:
       - id: set-versions
         run: echo "versions=$(./get_json_versions.py)" >> $GITHUB_OUTPUT
 
-      # Push image base
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      ## Check if there are modifications in the base/ directory
-      ## and store it in the variable `steps.changes.outputs.base`
-      ## The variable is built like: steps.{#id}.outputs.{#filter}
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            base:
-              - 'base/**'
-
-      - name: Base Images > Generate Tags
-        run: ./generate_tags.sh
-        working-directory: base
-
-      - name: Base Images > Docker Build Tags
-        run: ./docker_tags.sh
-        if: ${{ github.event_name == 'pull_request' }}
-        working-directory: base
-
-      - name: Base Images > Docker Build & Force Push
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changes.outputs.base == 'true' }}
-        run: ./docker_tags.sh -p -f
-        working-directory: base
-    outputs:
-      versions: ${{ steps.set-versions.outputs.versions }}
-
-  publish_images:
+  publish_base:
     runs-on: ubuntu-latest
-    needs: publish_base
+    needs: list_base_images
     strategy:
-      fail-fast: false
-      matrix:
-        ps-version: ${{ fromJson(needs.publish_base.outputs.versions) }}
+        matrix:
+            manifest: ${{ fromJson(needs.list_base_images.outputs.versions) }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Enable multi-platform builds
+        run: docker buildx create --name container --driver=docker-container
+
+      - uses: actions/checkout@v2
+
+      - name: Base Images > Generate Tags
+        run: ./generate_tags.sh
+        working-directory: base
+
+      - name: Base Images > Docker Build Tags
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./docker_tags.sh --version ${{ matrix.version }}
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: base
+
+      - name: Base Images > Docker Build & Force Push
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.list_base_images.outputs.base_has_changed == 'true' }}
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./docker_tags.sh -p -f --version ${{ matrix.version }}
+        working-directory: base
+
+
+  publish_prestashop:
+    runs-on: ubuntu-latest
+    needs:
+      - list_prestashop_images
+      - publish_base
+    strategy:
+      fail-fast: false
+      matrix:
+        ps-version: ${{ fromJson(needs.list_prestashop_images.outputs.versions) }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Enable multi-platform builds
+        run: docker buildx create --name container --driver=docker-container
 
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -73,9 +97,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Build Docker images
-        run: ./prestashop_docker.py --quiet tag build ${{ matrix.ps-version }} --force
-
-      - name: Push Docker images
+      - name: Build & Push Docker images
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        run: ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }} --force
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }} --force
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
     needs: list_base_images
     strategy:
         matrix:
-            manifest: ${{ fromJson(needs.list_base_images.outputs.versions) }}
+            version: ${{ fromJson(needs.list_base_images.outputs.versions) }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -60,13 +60,13 @@ jobs:
         working-directory: base
 
       - name: Base Images > Docker Build Tags
-        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./docker_tags.sh --version ${{ matrix.version }}
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_BASE_REPOSITORY}} ./docker_tags.sh --version ${{ matrix.version }}
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: base
 
       - name: Base Images > Docker Build & Force Push
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.list_base_images.outputs.base_has_changed == 'true' }}
-        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./docker_tags.sh -p -f --version ${{ matrix.version }}
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_BASE_REPOSITORY}} ./docker_tags.sh -p -f --version ${{ matrix.version }}
         working-directory: base
 
 

--- a/HOW-TO-USE.md
+++ b/HOW-TO-USE.md
@@ -9,6 +9,12 @@ It requires Python 3.9+.
 $ pip install -r requirements.txt --break-system-packages
 ```
 
+If you plan to build the images locally, you'll need to create a builder instance. This command just needs to be run one time.
+
+```bash
+$ docker buildx create --name container --driver=docker-container
+```
+
 ## Usage
 
 Display the help:
@@ -68,10 +74,10 @@ positional arguments:
   {exists,build,push,aliases}
     exists              Check if tag exists on Docker Hub
     build               Build container and create docker tag
-    push                Push docker tags
+    push                Build container and create docker tag then push docker tags
     aliases             Get aliases
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
 ```
 
@@ -126,7 +132,7 @@ $ nosetests --with-id 7
 
 This will also generate a `.nodeids` binary file, when you add new test methods you need to remove this file to re-generate the list of IDs.
 
-## Building and running PrestaShop docker locally
+## Building and running PrestaShop docker locally (local platform only, deprecated)
 
 First to make sure you will use the local docker containers and not the ones from Docker hub make sure you remove all existing PrestaShop images (including the base images)
 

--- a/base/docker_tags.sh
+++ b/base/docker_tags.sh
@@ -3,6 +3,7 @@
 : ${PLATFORM_ARGS:="linux/arm/v7,linux/arm64/v8,linux/amd64"}
 : ${DOCKER_REPOSITORY:="prestashop/base"}
 
+set -e 
 cd $(cd "$( dirname "$0" )" && pwd)
 
 # Default values

--- a/base/generate_tags.sh
+++ b/base/generate_tags.sh
@@ -31,7 +31,7 @@ generate_image()
 
     if [ -d images/$folder ] && [ -z "$FORCE" ]; then
         # Do not erase what we already defined in the directory
-        echo Already defined, skipping Use -f to forcre update
+        echo Already defined, skipping Use -f to force update
         return
     fi
 

--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -24,6 +24,10 @@ PS_HANDLE_DYNAMIC_DOMAIN=0 \
 PS_FOLDER_ADMIN=admin \
 PS_FOLDER_INSTALL=install
 
+RUN sed -ie "s/deb.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && sed -ie "s/security.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && echo 'Sources list updated'
+
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -24,6 +24,10 @@ PS_HANDLE_DYNAMIC_DOMAIN=0 \
 PS_FOLDER_ADMIN=admin \
 PS_FOLDER_INSTALL=install
 
+RUN sed -ie "s/deb.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && sed -ie "s/security.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && echo 'Sources list updated'
+
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -24,6 +24,10 @@ PS_HANDLE_DYNAMIC_DOMAIN=0 \
 PS_FOLDER_ADMIN=admin \
 PS_FOLDER_INSTALL=install
 
+RUN sed -ie "s/deb.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && sed -ie "s/security.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && echo 'Sources list updated'
+
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -24,6 +24,10 @@ PS_HANDLE_DYNAMIC_DOMAIN=0 \
 PS_FOLDER_ADMIN=admin \
 PS_FOLDER_INSTALL=install
 
+RUN sed -ie "s/deb.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && sed -ie "s/security.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && echo 'Sources list updated'
+
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \

--- a/base/tags.txt
+++ b/base/tags.txt
@@ -1,5 +1,3 @@
-7.1-apache
-7.2-apache
 7.3-apache
 7.4-apache
 8.0-apache
@@ -7,8 +5,6 @@
 8.2-apache
 8.3-apache
 8.4-apache
-7.1-fpm
-7.2-fpm
 7.3-fpm
 7.4-fpm
 8.0-fpm

--- a/prestashop_docker.py
+++ b/prestashop_docker.py
@@ -138,7 +138,7 @@ def main():
             elif args.tag_subcommand == 'build':
                 tag_manager.build(args.version, args.force)
             elif args.tag_subcommand == 'push':
-                tag_manager.push(args.version, args.force)
+                tag_manager.build(args.version, args.force, True)
             elif args.tag_subcommand == 'aliases':
                 tag_manager.get_aliases(args.version)
     else:

--- a/prestashop_docker.py
+++ b/prestashop_docker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import docker
+import os
 from versions import VERSIONS
 from prestashop_docker.backlog import Backlog
 from prestashop_docker.generator import Generator
@@ -11,6 +12,8 @@ from prestashop_docker.version_manager import VersionManager
 from os import path
 import argparse
 import logging
+
+docker_repository_name = os.getenv('DOCKER_REPOSITORY', 'prestashop/prestashop')
 
 
 def get_parser():
@@ -53,7 +56,7 @@ def get_tag_parser(subparser):
 
     push_parser = tag_subparser.add_parser(
         'push',
-        help='Push docker tags'
+        help='Build container and create docker tag then push docker tags'
     )
     push_parser.add_argument('version', type=str, help='Version name', nargs='?')
     push_parser.add_argument('--force', action='store_const', const=True, help='Force build even if image already exists on Docker hub', default=False)
@@ -125,7 +128,8 @@ def main():
             docker.from_env(),
             VersionManager(path.join(path.dirname(path.realpath(__file__)), 'images')),
             args.cache,
-            args.quiet
+            args.quiet,
+            docker_repository_name,
         )
         if args.tag_subcommand is None:
             tag_parser.print_help()

--- a/prestashop_docker/docker_api.py
+++ b/prestashop_docker/docker_api.py
@@ -28,7 +28,7 @@ class DockerApi():
         if self.cache:
             requests_cache.install_cache('cache')
 
-    def get_tags(self, image_name='prestashop/prestashop'):
+    def get_tags(self, image_name):
         """Generate return tags
 
         @return: The json content


### PR DESCRIPTION
- [x] Require merge of #424 first.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR allows the docker images (prestashop/base and prestashop/prestashop) to be built for amd64, arm32 and arm64
| Type?             | new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/docker/issues/315
| Sponsor company   | @PrestaShopCorp
| How to test?      | The existing commands generate the images for different kind of CPUs

* Given the time needed to build each image (given the emulation of other processors), the GitHub action workflow has been split for each image to generate
<img width="1055" height="589" alt="image" src="https://github.com/user-attachments/assets/4741a203-e3e0-40b6-801b-87e6f4583a24" />

* Build test of Docker base images are done on `quetzacoalt/base`: https://hub.docker.com/repository/docker/quetzacoalt/base/tags
* Build test of Docker PrestaShop images are done on `quetzacoalt/prestashop`: https://hub.docker.com/repository/docker/quetzacoalt/prestashop/tags