### PR TITLE
Stop installing a lib deleted on Debian Trixie

### DIFF
--- a/base/Dockerfile.model
+++ b/base/Dockerfile.model
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/7.3-apache/Dockerfile
+++ b/base/images/7.3-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 # PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath

--- a/base/images/7.3-fpm/Dockerfile
+++ b/base/images/7.3-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 # PHP < 7.4 have an old syntax to install GD. See https://github.com/docker-library/php/issues/912
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath

--- a/base/images/7.4-apache/Dockerfile
+++ b/base/images/7.4-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/7.4-fpm/Dockerfile
+++ b/base/images/7.4-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.0-apache/Dockerfile
+++ b/base/images/8.0-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.0-fpm/Dockerfile
+++ b/base/images/8.0-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.1-apache/Dockerfile
+++ b/base/images/8.1-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.1-fpm/Dockerfile
+++ b/base/images/8.1-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.2-apache/Dockerfile
+++ b/base/images/8.2-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.2-fpm/Dockerfile
+++ b/base/images/8.2-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.3-apache/Dockerfile
+++ b/base/images/8.3-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.3-fpm/Dockerfile
+++ b/base/images/8.3-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.4-apache/Dockerfile
+++ b/base/images/8.4-apache/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 

--- a/base/images/8.4-fpm/Dockerfile
+++ b/base/images/8.4-fpm/Dockerfile
@@ -27,7 +27,6 @@ PS_FOLDER_INSTALL=install
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
         libpng-dev \
         libwebp-dev \
         libfreetype6-dev \
@@ -37,9 +36,13 @@ RUN apt-get update \
         default-mysql-client \
         wget \
         unzip \
-        libonig-dev
+        libonig-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /var/lib/apt/lists/*
+RUN if [[ "$(cat /etc/os-release)" == *"bookworm"* ]]; then apt-get update \
+    && apt-get install -y libpcre3-dev \
+    && rm -rf /var/lib/apt/lists/*; fi
+
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include
 RUN docker-php-ext-install iconv intl pdo_mysql mbstring soap gd zip bcmath
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Images of PHP 8+ are now based on Debian Trixie (see https://github.com/docker-library/php/pull/1596/). We had an issue from a lib we install via apt (`E: Package 'libpcre3-dev' has no installation candidate`), and this PR only install it if the current OS is older than Debian Trixie.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Build still pass

<img width="1888" height="985" alt="image" src="https://github.com/user-attachments/assets/68fbce08-8959-4fdb-b169-6e0f034ebef8" />
