### PR TITLE
Avoid API limit by querying Docker Hub unauthenticated in Github Actions, and build only if needed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-versions
         run: echo "versions=$(ls base/images/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -81,42 +81,55 @@ jobs:
     needs:
       - list_prestashop_images
       - publish_base
+      - list_base_images
     strategy:
       max-parallel: 2
       fail-fast: false
       matrix:
         ps-version: ${{ fromJson(needs.list_prestashop_images.outputs.versions) }}
     steps:
+      - uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            image_has_changed:
+              - 'images/${{ matrix.ps-version }}/**'
+
       - name: Set up QEMU
+        if: ${{ steps.filter.outputs.image_has_changed == 'true' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Enable multi-platform builds
+        if: ${{ steps.filter.outputs.image_has_changed == 'true' }}
         uses: docker/setup-buildx-action@v3
         with:
           name: container
           version: latest
 
-      - uses: actions/checkout@v2
-
       - name: Set up Python
+        if: ${{ steps.filter.outputs.image_has_changed == 'true' }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
 
       - name: Install dependencies
+        if: ${{ steps.filter.outputs.image_has_changed == 'true' }}
         run: pip install -r requirements.txt
 
       - name: Build Docker images
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ steps.filter.outputs.image_has_changed == 'true' }}
         run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./prestashop_docker.py --quiet tag build ${{ matrix.ps-version }} --force
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && (needs.list_base_images.outputs.base_has_changed == 'true' || steps.filter.outputs.image_has_changed == 'true') }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build by using cache and push Docker images
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && (needs.list_base_images.outputs.base_has_changed == 'true' || steps.filter.outputs.image_has_changed == 'true') }}
         run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }} --force
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,8 +50,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Enable multi-platform builds
-        run: docker buildx create --name container --driver=docker-container
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: container
+          version: latest
 
       - uses: actions/checkout@v2
 
@@ -81,8 +87,14 @@ jobs:
       matrix:
         ps-version: ${{ fromJson(needs.list_prestashop_images.outputs.versions) }}
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Enable multi-platform builds
-        run: docker buildx create --name container --driver=docker-container
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: container
+          version: latest
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,24 +81,30 @@ jobs:
       matrix:
         ps-version: ${{ fromJson(needs.list_prestashop_images.outputs.versions) }}
     steps:
+      - name: Enable multi-platform builds
+        run: docker buildx create --name container --driver=docker-container
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build Docker images
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./prestashop_docker.py --quiet tag build ${{ matrix.ps-version }} --force
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Enable multi-platform builds
-        run: docker buildx create --name container --driver=docker-container
-
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Build & Push Docker images
+      - name: Build by using cache and push Docker images
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: DOCKER_REPOSITORY=${{ vars.DOCKER_REPOSITORY}} ./prestashop_docker.py --quiet tag push ${{ matrix.ps-version }} --force
 

--- a/prestashop_docker/tag_manager.py
+++ b/prestashop_docker/tag_manager.py
@@ -71,6 +71,7 @@ class TagManager():
                 "docker", "buildx", "build",
                 "--platform", "linux/arm/v7,linux/arm64/v8,linux/amd64",
                 "--builder", "container",
+                "--progress", "plain",
             ] + tags + args + [
                 str(version_path)
             ]


### PR DESCRIPTION
<!----------------------------------------------------------------br-------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Building all the PrestaShop images fails because of the number of API calls allowed reached in a limited period of time. Pulls from Docker Hub could be allowed without limit when we are not authenticated on GitHub Actions environments. This PR limits the risk of quota exceeded by: <ul><li>pulling without being authenticated,</li><li>building images only if a change has been found.</li></ul>
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Builds succeed on a fork<ul><li>Job without any change -> No image is built (https://github.com/Quetzacoalt91/docker/actions/runs/17497546687)</li><li>Job from a commit with a diff in the folder images/1.7.4.0 -> Build of 1.7.4.0 (https://github.com/Quetzacoalt91/docker/actions/runs/17497546687/job/49702193446)
</li></ul>

<img width="326" height="430" alt="image" src="https://github.com/user-attachments/assets/cdfb380b-1db2-473a-9e56-ae85028c5d0c" />