### PR TITLE
chore: fix MySQL client to disable SSL verification

### DIFF
--- a/base/Dockerfile.model
+++ b/base/Dockerfile.model
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.1-apache/Dockerfile
+++ b/base/images/7.1-apache/Dockerfile
@@ -64,6 +64,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.1-fpm/Dockerfile
+++ b/base/images/7.1-fpm/Dockerfile
@@ -64,6 +64,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.2-apache/Dockerfile
+++ b/base/images/7.2-apache/Dockerfile
@@ -64,6 +64,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.2-fpm/Dockerfile
+++ b/base/images/7.2-fpm/Dockerfile
@@ -64,6 +64,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.3-apache/Dockerfile
+++ b/base/images/7.3-apache/Dockerfile
@@ -63,6 +63,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.3-fpm/Dockerfile
+++ b/base/images/7.3-fpm/Dockerfile
@@ -63,6 +63,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.4-apache/Dockerfile
+++ b/base/images/7.4-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/7.4-fpm/Dockerfile
+++ b/base/images/7.4-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.0-apache/Dockerfile
+++ b/base/images/8.0-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.0-fpm/Dockerfile
+++ b/base/images/8.0-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.1-apache/Dockerfile
+++ b/base/images/8.1-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.1-fpm/Dockerfile
+++ b/base/images/8.1-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.2-apache/Dockerfile
+++ b/base/images/8.2-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.2-fpm/Dockerfile
+++ b/base/images/8.2-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.3-apache/Dockerfile
+++ b/base/images/8.3-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.3-fpm/Dockerfile
+++ b/base/images/8.3-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.4-apache/Dockerfile
+++ b/base/images/8.4-apache/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 

--- a/base/images/8.4-fpm/Dockerfile
+++ b/base/images/8.4-fpm/Dockerfile
@@ -62,6 +62,12 @@ COPY config_files/docker_updt_ps_domains.php /tmp/
 COPY config_files/defines_custom.inc.php /tmp/
 RUN chown www-data:www-data /tmp/defines_custom.inc.php
 
+# Force mysql client to disable SSL only in dev mode
+RUN if [ "$PS_DEV_MODE" = "1" ]; then \
+        mkdir -p /etc/mysql/conf.d \
+        && echo "[client]\nssl=0\n" > /etc/mysql/conf.d/disable-ssl.cnf; \
+    fi
+
 # Apache configuration
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While upgrading base image to Debian Trixie, it introduced an error related to self-signed SSL certificate.<br>My assumption is that the default-mysql-client package has been updated from 1.0.7 to 1.1.1.<br>This PR forces the `ssl=0` option to fix those blocking issues.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39435 and https://github.com/PrestaShop/PrestaShop/issues/39456
| Sponsor company   | ~
| How to test?      | ~
