### PR TITLE
Do not clean up GitHub Action workers if no Docker build is needed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
             version: ${{ fromJson(needs.list_base_images.outputs.versions) }}
     steps:
       - name: Free Disk Space (Ubuntu)
+        if: ${{ needs.list_base_images.outputs.base_has_changed == 'true' }}
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,
@@ -61,15 +62,18 @@ jobs:
           swap-storage: true
 
       - name: Login to Docker Hub
+        if: ${{ needs.list_base_images.outputs.base_has_changed == 'true' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
+        if: ${{ needs.list_base_images.outputs.base_has_changed == 'true' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Enable multi-platform builds
+        if: ${{ needs.list_base_images.outputs.base_has_changed == 'true' }}
         uses: docker/setup-buildx-action@v3
         with:
           name: container
@@ -79,11 +83,6 @@ jobs:
 
       - name: Base Images > Generate Tags
         run: ./generate_tags.sh
-        working-directory: base
-
-      - name: Base Images > Docker Build Tags
-        run: DOCKER_REPOSITORY=${{ vars.DOCKER_BASE_REPOSITORY}} ./docker_tags.sh --version ${{ matrix.version }}
-        if: ${{ github.event_name == 'pull_request' }}
         working-directory: base
 
       - name: Base Images > Docker Build & Force Push
@@ -114,6 +113,7 @@ jobs:
               - 'images/${{ matrix.ps-version }}/**'
 
       - name: Free Disk Space (Ubuntu)
+        if: ${{ (needs.list_base_images.outputs.base_has_changed == 'true' || steps.filter.outputs.image_has_changed == 'true') }}
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Based on the run https://github.com/PrestaShop/docker/actions/runs/23484488854, each task of building a base or PrestaShop image takes ~2 minutes even when there is nothing to do. This is caused by the step `jlumbroso/free-disk-space` that frees space in order to the incoming Docker build to complete. However, 2 minutes * (83-5) jobs equals around 1h and a half (156 minutes) of wasted runners time. This PR adds conditions to avoid running steps that won't be needed, and will speed up the whole workflow.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check time needed to complete (to be checked on a fork: https://github.com/Quetzacoalt91/docker/actions/runs/23496129187)

## Original behavior:

<img width="1080" height="813" alt="image" src="https://github.com/user-attachments/assets/57e6ab46-2cd3-4cf5-b726-d91b928e4dae" />


## Updated result:

<img width="1080" height="813" alt="image" src="https://github.com/user-attachments/assets/462794ef-b8a6-406e-9779-7046196d3740" />
